### PR TITLE
Use to the new girder jobs update events.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ compiler:
 
 before_install:
     
-    - GIRDER_VERSION=d910e905c4196e3046a129d0edb84e5c7e301596
+    - GIRDER_VERSION=492acc9a011a6cc784a9295e466946da13198587
     - GIRDER_WORKER_VERSION=f834d4d3701df7f6f3f64fcd7d3f22d15b3b1db2
     - main_path=$PWD
     - build_path=$PWD/build

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -36,5 +36,5 @@ def load(info):
 
     genRESTEndPointsForSlicerCLIsInDockerCache(resource, dockerCache)
 
-    events.bind('model.job.save.after', resource.resourceName,
+    events.bind('jobs.job.update.after', resource.resourceName,
                 resource.AddRestEndpoints)

--- a/server/docker_resource.py
+++ b/server/docker_resource.py
@@ -286,17 +286,13 @@ class DockerResource(Resource):
         and endpoints fro all cached docker images are regenerated
         :param event: An event dictionary
         """
+        job = event.info['job']
 
-        job = event.info
+        if job['type'] == self.jobType and job['status'] == JobStatus.SUCCESS:
+            # remove all previous endpoints
+            dockermodel = ModelImporter.model('docker_image_model',
+                                              'slicer_cli_web')
+            cache = dockermodel.loadAllImages()
 
-        if job['type'] == self.jobType and job['status']\
-                == JobStatus.SUCCESS:
-
-                # remove all previous endpoints
-                dockermodel = ModelImporter.model('docker_image_model',
-                                                  'slicer_cli_web')
-
-                cache = dockermodel.loadAllImages()
-
-                self.deleteImageEndpoints()
-                genRESTEndPointsForSlicerCLIsInDockerCache(self, cache)
+            self.deleteImageEndpoints()
+            genRESTEndPointsForSlicerCLIsInDockerCache(self, cache)


### PR DESCRIPTION
Job updates no longer result in model.job.save.after events.  Instead, there is a similar jobs.job.update.after event.
