### PR TITLE
server/cli_list_entrypoint: Fix execution of C++ CLIs

### DIFF
--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -90,7 +90,7 @@ def CLIListEntrypoint(cli_list_spec_file=None):
         script_file = os.path.join('.', args.cli, os.path.basename(args.cli))
 
         # ./<cli-rel-path>/<cli-name> [<args>]
-        subprocess.call(script_file + sys.argv[2:])
+        subprocess.call([script_file] + sys.argv[2:])
 
     else:
         raise Exception(


### PR DESCRIPTION
This commit fixes the following error:

```
Traceback (most recent call last):
  File "/build/slicer_cli_web/server/cli_list_entrypoint.py", line 102, in <module>
    CLIListEntrypoint()
  File "/build/slicer_cli_web/server/cli_list_entrypoint.py", line 93, in CLIListEntrypoint
    subprocess.call(script_file + sys.argv[2:])
TypeError: cannot concatenate 'str' and 'list' objects
```