### PR TITLE
Use temp files instead of the local directory.

### DIFF
--- a/server/docker_resource.py
+++ b/server/docker_resource.py
@@ -22,6 +22,7 @@ import six
 import json
 
 from girder.api.v1.resource import Resource, RestException
+from girder import logger
 
 from girder.utility.model_importer import ModelImporter
 
@@ -274,8 +275,8 @@ class DockerResource(Resource):
                             self.removeRoute(endpoint[0], endpoint[1],
                                              getattr(self, endpoint[2]))
                             delattr(self, endpoint[2])
-                        except Exception as err:
-                            print err
+                        except Exception:
+                            logger.exception('Failed to remove route')
             del self.currentEndpoints[imageName]
 
     def AddRestEndpoints(self, event):


### PR DESCRIPTION
Use girder.logger instead of print statements.

If girder lacks permissions for the local directory, generating endpoints would fail.