### PR TITLE
Add Dockerfile to generate a base image for plugins

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # Created by .ignore support plugin (hsz.mobi)
+
 ### Vim template
 # swap
 [._]*.s[a-w][a-z]
@@ -8,9 +9,11 @@ Session.vim
 # temporary
 .netrwhist
 *~
+
 # auto-generated tag files
 tags
-### C++ template
+
+### Cpp template
 # Compiled Object files
 *.slo
 *.lo
@@ -40,6 +43,7 @@ tags
 *.exe
 *.out
 *.app
+
 ### CMake template
 CMakeCache.txt
 CMakeFiles
@@ -48,6 +52,7 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
+
 ### Emacs template
 # -*- mode: gitignore; -*-
 *~
@@ -103,6 +108,7 @@ flycheck_*.el
 pyvenv.cfg
 .venv
 pip-selfcheck.json
+
 ### Linux template
 *~
 
@@ -114,6 +120,7 @@ pip-selfcheck.json
 
 # Linux trash folder which might appear on any partition or disk
 .Trash-*
+
 ### C template
 # Object files
 *.o
@@ -148,6 +155,7 @@ pip-selfcheck.json
 # Debug files
 *.dSYM/
 *.su
+
 ### Windows template
 # Windows image file caches
 Thumbs.db
@@ -167,9 +175,11 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
 ### KDevelop4 template
 *.kdev4
 .kdev4/
+
 ### Python template
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,287 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Vim template
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags
+### C++ template
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+### CMake template
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Makefile
+cmake_install.cmake
+install_manifest.txt
+CTestTestfile.cmake
+### Emacs template
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+### C template
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+### Windows template
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### KDevelop4 template
+*.kdev4
+.kdev4/
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+### Xcode template
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+FROM ubuntu:16.04
+MAINTAINER Deepak Roy Chittajallu <deepk.chittajallu@kitware.com>
+
+# Install system pre-requisites
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    wget \
+    git \
+    emacs vim \
+    make cmake cmake-curses-gui \
+    ninja-build && \
+    apt-get autoremove && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Working directory
+ENV build_path=$PWD/build
+
+# Install miniconda
+RUN mkdir -p $build_path && \
+    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
+    -O $build_path/install_miniconda.sh && \
+    bash $build_path/install_miniconda.sh -b -p $build_path/miniconda && \
+    rm $build_path/install_miniconda.sh && \
+    chmod -R +r $build_path && \
+    chmod +x $build_path/miniconda/bin/python
+ENV PATH=$build_path/miniconda/bin:${PATH}
+
+# Install CMake
+ENV CMAKE_ARCHIVE_SHA256 fdda4a8324e23c705ef0c2c45ba934ff3bd43798fb5631eec2d453693dbe777c
+ENV CMAKE_VERSION_MAJOR 3
+ENV CMAKE_VERSION_MINOR 6
+ENV CMAKE_VERSION_PATCH 1
+ENV CMAKE_VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}.${CMAKE_VERSION_PATCH}
+RUN cd $build_path && \
+  wget https://cmake.org/files/v${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
+  hash=$(sha256sum ./cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | awk '{ print $1 }') && \
+  [ $hash = "${CMAKE_ARCHIVE_SHA256}" ] && \
+  tar -xzvf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
+  rm cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+ENV PATH=$build_path/cmake-${CMAKE_VERSION}-Linux-x86_64/bin:${PATH}
+
+# Disable "You are in 'detached HEAD' state." warning
+RUN git config --global advice.detachedHead false
+
+# Download/configure/build/install ITK for SlicerExecutionModel (needed only for C++ CLIs)
+ENV ITK_GIT_TAG v4.10.0
+RUN cd $build_path && git clone --depth 1 -b ${ITK_GIT_TAG} git://itk.org/ITK.git && \
+    mkdir ITK-build && \
+    cd ITK-build && \
+    cmake \
+        -G Ninja \
+        -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+        -DBUILD_EXAMPLES:BOOL=OFF \
+        -DBUILD_TESTING:BOOL=OFF \
+        -DBUILD_SHARED_LIBS:BOOL=ON \
+        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
+        -DITK_LEGACY_REMOVE:BOOL=ON \
+        -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF \
+        -DITK_USE_SYSTEM_LIBRARIES:BOOL=OFF \
+        -DModule_ITKCommon:BOOL=ON \
+        -DModule_ITKIOXML:BOOL=ON \
+        -DModule_ITKExpat:BOOL=ON \
+        ../ITK && \
+    ninja install && \
+    rm -rf ITK ITK-build
+
+# Download/configure/build SlicerExecutionModel (needed only for C++ CLIs)
+ENV SEM_GIT_TAG 7525fc777a064529aff55e41aef6d91a85074553
+RUN cd $build_path && \
+    git clone git://github.com/Slicer/SlicerExecutionModel.git && \
+    (cd SlicerExecutionModel && git checkout ${SEM_GIT_TAG}) && \
+    mkdir SEM-build && cd SEM-build && \
+    cmake \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DBUILD_TESTING:BOOL=OFF \
+        ../SlicerExecutionModel && \
+    ninja
+
+# Install ctk-cli
+RUN conda install --yes -c cdeepakroy ctk-cli=1.3.1
+
+# copy slicer_cli_web files
+ENV slicer_cli_web_path=$build_path/slicer_cli_web
+RUN mkdir -p $slicer_cli_web_path
+COPY . $slicer_cli_web_path/
+WORKDIR $slicer_cli_web_path/server

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,17 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Working directory
-ENV build_path=$PWD/build
+ENV BUILD_PATH=$PWD/build
 
 # Install miniconda
-RUN mkdir -p $build_path && \
+RUN mkdir -p $BUILD_PATH && \
     wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
-    -O $build_path/install_miniconda.sh && \
-    bash $build_path/install_miniconda.sh -b -p $build_path/miniconda && \
-    rm $build_path/install_miniconda.sh && \
-    chmod -R +r $build_path && \
-    chmod +x $build_path/miniconda/bin/python
-ENV PATH=$build_path/miniconda/bin:${PATH}
+    -O $BUILD_PATH/install_miniconda.sh && \
+    bash $BUILD_PATH/install_miniconda.sh -b -p $BUILD_PATH/miniconda && \
+    rm $BUILD_PATH/install_miniconda.sh && \
+    chmod -R +r $BUILD_PATH && \
+    chmod +x $BUILD_PATH/miniconda/bin/python
+ENV PATH=$BUILD_PATH/miniconda/bin:${PATH}
 
 # Install CMake
 ENV CMAKE_ARCHIVE_SHA256 fdda4a8324e23c705ef0c2c45ba934ff3bd43798fb5631eec2d453693dbe777c
@@ -32,20 +32,20 @@ ENV CMAKE_VERSION_MAJOR 3
 ENV CMAKE_VERSION_MINOR 6
 ENV CMAKE_VERSION_PATCH 1
 ENV CMAKE_VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}.${CMAKE_VERSION_PATCH}
-RUN cd $build_path && \
+RUN cd $BUILD_PATH && \
   wget https://cmake.org/files/v${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
   hash=$(sha256sum ./cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | awk '{ print $1 }') && \
   [ $hash = "${CMAKE_ARCHIVE_SHA256}" ] && \
   tar -xzvf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz && \
   rm cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
-ENV PATH=$build_path/cmake-${CMAKE_VERSION}-Linux-x86_64/bin:${PATH}
+ENV PATH=$BUILD_PATH/cmake-${CMAKE_VERSION}-Linux-x86_64/bin:${PATH}
 
 # Disable "You are in 'detached HEAD' state." warning
 RUN git config --global advice.detachedHead false
 
 # Download/configure/build/install ITK for SlicerExecutionModel (needed only for C++ CLIs)
 ENV ITK_GIT_TAG v4.10.0
-RUN cd $build_path && git clone --depth 1 -b ${ITK_GIT_TAG} git://itk.org/ITK.git && \
+RUN cd $BUILD_PATH && git clone --depth 1 -b ${ITK_GIT_TAG} git://itk.org/ITK.git && \
     mkdir ITK-build && \
     cd ITK-build && \
     cmake \
@@ -67,7 +67,7 @@ RUN cd $build_path && git clone --depth 1 -b ${ITK_GIT_TAG} git://itk.org/ITK.gi
 
 # Download/configure/build SlicerExecutionModel (needed only for C++ CLIs)
 ENV SEM_GIT_TAG 7525fc777a064529aff55e41aef6d91a85074553
-RUN cd $build_path && \
+RUN cd $BUILD_PATH && \
     git clone git://github.com/Slicer/SlicerExecutionModel.git && \
     (cd SlicerExecutionModel && git checkout ${SEM_GIT_TAG}) && \
     mkdir SEM-build && cd SEM-build && \
@@ -82,7 +82,7 @@ RUN cd $build_path && \
 RUN conda install --yes -c cdeepakroy ctk-cli=1.3.1
 
 # copy slicer_cli_web files
-ENV slicer_cli_web_path=$build_path/slicer_cli_web
+ENV slicer_cli_web_path=$BUILD_PATH/slicer_cli_web
 RUN mkdir -p $slicer_cli_web_path
 COPY . $slicer_cli_web_path/
 WORKDIR $slicer_cli_web_path/server

--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -5,8 +5,6 @@ import argparse
 import subprocess
 import textwrap as _textwrap
 
-from girder import logger
-
 
 class _MultilineHelpFormatter(argparse.HelpFormatter):
     def _fill_text(self, text, width, indent):
@@ -95,9 +93,7 @@ def CLIListEntrypoint(cli_list_spec_file=None):
         subprocess.call([script_file] + sys.argv[2:])
 
     else:
-        logger.exception('CLIs of type %s are not supported',
-                         cli_list_spec[args.cli]['type'])
-        raise Exception(
+       raise Exception(
             'CLIs of type %s are not supported',
             cli_list_spec[args.cli]['type']
         )

--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -93,7 +93,7 @@ def CLIListEntrypoint(cli_list_spec_file=None):
         subprocess.call([script_file] + sys.argv[2:])
 
     else:
-       raise Exception(
+        raise Exception(
             'CLIs of type %s are not supported',
             cli_list_spec[args.cli]['type']
         )


### PR DESCRIPTION
Added a Dockerfile to generate a base image that can be used by all slicer_cli_web plugins.

This Dockerfile does the following:
* apt-get install system pre-requisites
* Download and Install miniconda
* Download and Install CMake
* git clone and build ITK 4.10
* git clone and build SlicerExecutionModel
* Install ctk_cli=1.3.1 from my conda channel
* Copy in files of slicer_cli_web
