### PR TITLE
	Fix parsing JSON lists of docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,13 @@ before_install:
     - ln -sf $HOME/.cache/node_modules .
     - npm install -g npm
     - npm --version
+    - npm install -g npm-install-retry
     - npm prune
 
     - wget -O $build_path/install_miniconda.sh https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
     - bash $build_path/install_miniconda.sh -b -p $build_path/miniconda
     - source $build_path/miniconda/bin/activate $build_path/miniconda
-    - conda update --yes --all
+    - conda update --yes --all 'python<=2.7.12'
     - conda config --add channels https://conda.binstar.org/cdeepakroy
 
 install:
@@ -60,7 +61,7 @@ install:
     - conda install --yes setuptools==19.4 ctk-cli==1.3.1
     - cd $girder_path
     - pip install -U -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt setuptools==19.4
-    - npm install
+    - npm-install-retry
 
 script:
     - mkdir -p $build_path/girder_testing_build

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -73,15 +73,29 @@ class DockerImageManagementTest(base.TestCase):
 
     def testDockerAdd(self):
         # try to cache a good image to the mongo database
-        img_name = "dsarchive/histomicstk:v0.1.3"
+        img_name = 'dsarchive/histomicstk:v0.1.3'
         self.assertNoImages()
         self.addImage(img_name, JobStatus.SUCCESS)
         self.imageIsLoaded(img_name, True)
 
+    def testDockerAddList(self):
+        # try to cache a good image to the mongo database
+        img_name = 'dsarchive/histomicstk:v0.1.3'
+        self.assertNoImages()
+        self.addImage([img_name], JobStatus.SUCCESS)
+        self.imageIsLoaded(img_name, True)
+
+    def testDockerAddWithoutVersion(self):
+        # all images need a version or hash
+        img_name = 'dsarchive/histomicstk'
+        self.assertNoImages()
+        self.addImage(img_name, JobStatus.ERROR)
+        self.assertNoImages()
+
     def testDockerDelete(self):
         # just delete the meta data in the mongo database
         # dont attempt to delete the docker image
-        img_name = "dsarchive/histomicstk:v0.1.3"
+        img_name = 'dsarchive/histomicstk:v0.1.3'
         self.assertNoImages()
         self.addImage(img_name, JobStatus.SUCCESS)
         self.imageIsLoaded(img_name, True)
@@ -92,7 +106,7 @@ class DockerImageManagementTest(base.TestCase):
     def testDockerDeleteFull(self):
         # attempt to delete docker image metadata and the image off the local
         # machine
-        img_name = "dsarchive/histomicstk:v0.1.3"
+        img_name = 'dsarchive/histomicstk:v0.1.3'
         self.assertNoImages()
         self.addImage(img_name, JobStatus.SUCCESS)
         self.imageIsLoaded(img_name, True)
@@ -124,7 +138,7 @@ class DockerImageManagementTest(base.TestCase):
     def testXmlEndpoint(self):
         # loads an image and attempts to run an arbitrary xml endpoint
 
-        img_name = "dsarchive/histomicstk:v0.1.3"
+        img_name = 'dsarchive/histomicstk:v0.1.3'
         self.testDockerAdd()
 
         name, tag = self.splitName(img_name)
@@ -144,7 +158,7 @@ class DockerImageManagementTest(base.TestCase):
 
     def testEndpointDeletion(self):
 
-        img_name = "dsarchive/histomicstk:v0.1.3"
+        img_name = 'dsarchive/histomicstk:v0.1.3'
         self.testXmlEndpoint()
         data = self.getEndpoint()
         self.deleteImage(img_name, True)
@@ -200,7 +214,7 @@ class DockerImageManagementTest(base.TestCase):
     def assertNoImages(self):
         data = self.getEndpoint()
         self.assertEqual({}, data,
-                         " There should be no pre existing docker images ")
+                         ' There should be no pre existing docker images ')
 
     def deleteImage(self, name,  responseCodeOK, deleteDockerImage=False,
                     status=4):
@@ -230,8 +244,8 @@ class DockerImageManagementTest(base.TestCase):
 
         resp = self.request(path='/slicer_cli_web/slicer_cli_web/docker_image',
                             user=self.admin, method='DELETE',
-                            params={"name": json.dumps(name),
-                                    "delete_from_local_repo":
+                            params={'name': json.dumps(name),
+                                    'delete_from_local_repo':
                                         deleteDockerImage
                                     }, isJson=False)
         if responseCodeOK:
@@ -251,8 +265,7 @@ class DockerImageManagementTest(base.TestCase):
             else:
                 del self.delHandler
                 self.assertEqual(job_status[0], status,
-                                 "The status of the job should "
-                                 "match ")
+                                 'The status of the job should match ')
 
     def addImage(self, name, status):
         """test the put endpoint, name can be a string or a list of strings"""
@@ -280,7 +293,7 @@ class DockerImageManagementTest(base.TestCase):
 
         resp = self.request(path='/slicer_cli_web/slicer_cli_web/docker_image',
                             user=self.admin, method='PUT',
-                            params={"name": json.dumps(name)}, isJson=False)
+                            params={'name': json.dumps(name)}, isJson=False)
 
         self.assertStatus(resp, 200)
 
@@ -291,5 +304,4 @@ class DockerImageManagementTest(base.TestCase):
         else:
             del self.addHandler
             self.assertEqual(job_status[0], status,
-                             "The status of the job should "
-                             "match ")
+                             'The status of the job should match ')

--- a/server/docker_resource.py
+++ b/server/docker_resource.py
@@ -209,20 +209,17 @@ class DockerResource(Resource):
         docker_image_model = ModelImporter.model('docker_image_model',
                                                  'slicer_cli_web')
 
-        if isinstance(name, list):
-            for img in name:
-
-                if not isinstance(img, six.string_types):
-                    raise RestException('%s was not a valid string.' % img)
-                if ':' not in img or '@' not in img:
-                    raise RestException('Image %s does not have a tag or '
-                                        'digest' % img)
-
-        elif isinstance(name, six.string_types):
-                name = [name]
-        else:
+        if isinstance(name, six.string_types):
+            name = [name]
+        if not isinstance(name, list):
             raise RestException('a valid string or a list of '
                                 'strings was not passed in')
+        for img in name:
+            if not isinstance(img, six.string_types):
+                raise RestException('%s was not a valid string.' % img)
+            if ':' not in img and '@' not in img:
+                raise RestException('Image %s does not have a tag or digest' % img)
+
         docker_image_model.putDockerImage(name, self.jobType, True)
 
     def storeEndpoints(self, imgName, cli, operation, argList):

--- a/server/image_job.py
+++ b/server/image_job.py
@@ -222,8 +222,7 @@ def LoadMetaData(jobModel, job, docker_client, pullList, loadList, notExistSet):
             except DockerImageError as err:
                 jobModel.updateJob(
                     job,
-                    log='Error with recently'
-                        ' pulled image %s' % name + str(err) + '\n',
+                    log='Error with recently pulled image %s\n%s\n' % (name, err),
                     status=JobStatus.ERROR
                 )
                 errorState = True
@@ -236,14 +235,12 @@ def LoadMetaData(jobModel, job, docker_client, pullList, loadList, notExistSet):
             cache.addImage(dockerImg)
             jobModel.updateJob(
                 job,
-                log='Loaded meta data from pre-existing local'
-                    'image %s\n' % name
+                log='Loaded meta data from pre-existing local image %s\n' % name
             )
         except DockerImageError as err:
             jobModel.updateJob(
                 job,
-                log='Error with recently loading pre-existing image'
-                    'image %s \n ' % name + str(err) + '\n',
+                log='Error with recently loading pre-existing image %s\n%s\n' % (name, err),
                 status=JobStatus.ERROR
             )
             errorState = True


### PR DESCRIPTION
When docker images were passed as a JSON list, they had to have BOTH a version AND a digest (which I don't think is allowed), rather than EITHER a version OR a digest.  Now, simple string and lists are validated with the same code.