### PR TITLE
Add bash to the small docker test file

### DIFF
--- a/small-docker/Dockerfile
+++ b/small-docker/Dockerfile
@@ -2,6 +2,9 @@
 FROM python:2.7-alpine
 MAINTAINER David Manthey <david.manthey@kitware.com>
 
+# Ensure that we have bash, as girder_worker expects it
+RUN apk add --update bash && rm -rf /var/cache/apk/*
+
 # Since we are using a BusyBox varient, we need to use addgroup and adduser,
 # rather than let girder_worker use groupadd and useradd.  Those will fail,
 # which is allowed if the worker user and group exist.


### PR DESCRIPTION
Technically, girder_worker expects all Docker jobs to have bash.  This adds bash without increasing the size of the small docker file very much.

Depending on the exact version of docker, not having bash produces different results.  In Docker 1.13.0, I get an error without it (and a different error from Docker 1.12.6).