### PR TITLE
Trigger global events on widget changes

### DIFF
--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -382,9 +382,6 @@ girderTest.promise.then(function () {
             w.$('input').val('4').trigger('change');
             expect(w.model.value()).toBe(4);
 
-            w.$('input').val('not a number').trigger('change');
-            expect(w.$('.form-group').hasClass('has-error')).toBe(true);
-
             w.$('input').val('4').trigger('change');
             expect(w.$('.form-group').hasClass('has-error')).toBe(false);
         });

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -49,7 +49,7 @@ var ControlWidget = View.extend({
     change: function () {
         events.trigger('s:widgetChanged:' + this.model.get('type'), this.model);
         events.trigger('s:widgetChanged', this.model);
-        this.render();
+        this.render.apply(this, arguments);
     },
 
     remove: function () {

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 
 import View from 'girder/views/View';
+import events from 'girder/events';
 
 import ItemSelectorWidget from './ItemSelectorWidget';
 
@@ -25,9 +26,12 @@ var ControlWidget = View.extend({
     },
 
     initialize: function () {
-        this.listenTo(this.model, 'change', this.render);
+        this.listenTo(this.model, 'change', this.change);
         this.listenTo(this.model, 'destroy', this.remove);
         this.listenTo(this.model, 'invalid', this.invalid);
+        this.listenTo(events, 's:widgetSet:' + this.model.id, (value) => {
+            this.model.set('value', value);
+        });
     },
 
     render: function (_, options) {
@@ -42,7 +46,15 @@ var ControlWidget = View.extend({
         return this;
     },
 
+    change: function () {
+        events.trigger('s:widgetChanged:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetChanged', this.model);
+        this.render();
+    },
+
     remove: function () {
+        events.trigger('s:widgetRemoved:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetRemoved', this.model);
         this.$('.s-control-item[data-type="color"] .input-group').colorpicker('destroy');
         this.$('.s-control-item[data-type="range"] input').slider('destroy');
         this.$el.empty();
@@ -53,6 +65,8 @@ var ControlWidget = View.extend({
      * is invalid.  This is automatically triggered by the model's "invalid" event.
      */
     invalid: function () {
+        events.trigger('s:widgetInvalid:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetInvalid', this.model);
         this.$('.form-group').addClass('has-error');
     },
 


### PR DESCRIPTION
This allows disconnected parts of an application to respond to changes in and modify the contents of widgets.  The use case for this change at the moment is to draw a rectangle on an image in response to the value of a "region"-type parameter.  It would be used as follows:

```javascript
this.listenTo(events, 's:widgetChanged:region', this.drawRegion)
```
You can also listen to change events on all widgets by listening to the global event `s:widgetChanged`.  This is intended to be similar to how backbone's model `change` and `change:<attribute>` events work.

Similarly, this adds the ability to trigger changes to the value of a particular widget by a global event as in:

```javascript
events.trigger('s:widgetSet:widget-id', value)
```