### PR TITLE
Add region type to web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN cd $BUILD_PATH && \
     ninja
 
 # Install ctk-cli
-RUN conda install --yes -c cdeepakroy ctk-cli=1.3.1
+RUN conda install --yes -c cdeepakroy ctk-cli=1.4.1
 
 # copy slicer_cli_web files
 ENV slicer_cli_web_path=$BUILD_PATH/slicer_cli_web

--- a/plugin_tests/client/widget.js
+++ b/plugin_tests/client/widget.js
@@ -382,9 +382,6 @@ girderTest.promise.then(function () {
             w.$('input').val('4').trigger('change');
             expect(w.model.value()).toBe(4);
 
-            w.$('input').val('not a number').trigger('change');
-            expect(w.$('.form-group').hasClass('has-error')).toBe(true);
-
             w.$('input').val('4').trigger('change');
             expect(w.$('.form-group').hasClass('has-error')).toBe(false);
         });

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -29,9 +29,11 @@ _SLICER_TO_GIRDER_WORKER_TYPE_MAP = {
     'float-enumeration': 'number',
     'double-enumeration': 'number',
     'string-enumeration': 'string',
+    'region': 'number_list',
     'file': 'string',
     'directory': 'string',
-    'image': 'string'}
+    'image': 'string'
+}
 
 _SLICER_TYPE_TO_GIRDER_MODEL_MAP = {
     'image': 'file',
@@ -166,6 +168,8 @@ def _getParamDefaultVal(param):
         return param.default
     elif param.typ == 'boolean':
         return False
+    elif param.isVector():
+        return None
     elif param.isExternalType():
         return ""
     else:

--- a/web_client/models/WidgetModel.js
+++ b/web_client/models/WidgetModel.js
@@ -247,7 +247,7 @@ var WidgetModel = Backbone.Model.extend({
      */
     isNumeric: function () {
         return _.contains(
-            ['range', 'number', 'number-vector', 'number-enumeration'],
+            ['range', 'number', 'number-vector', 'number-enumeration', 'region'],
             this.get('type')
         );
     },
@@ -271,7 +271,7 @@ var WidgetModel = Backbone.Model.extend({
      */
     isVector: function () {
         return _.contains(
-            ['number-vector', 'string-vector'],
+            ['number-vector', 'string-vector', 'region'],
             this.get('type')
         );
     },
@@ -335,7 +335,8 @@ var WidgetModel = Backbone.Model.extend({
         'file',
         'directory',
         'new-file',
-        'image'
+        'image',
+        'region'
     ]
 });
 

--- a/web_client/parser/widget.js
+++ b/web_client/parser/widget.js
@@ -18,6 +18,7 @@ function widget(param) {
         'float-enumeration': 'number-enumeration',
         'double-enumeration': 'number-enumeration',
         'string-enumeration': 'string-enumeration',
+        region: 'region',
         image: 'image',
         file: 'file',
         directory: 'directory'

--- a/web_client/stylesheets/controlWidget.styl
+++ b/web_client/stylesheets/controlWidget.styl
@@ -5,3 +5,7 @@
   font-size 12px
   color #666
   margin-bottom 4px
+
+.s-control-item
+  input.form-control
+    height auto

--- a/web_client/stylesheets/panelGroup.styl
+++ b/web_client/stylesheets/panelGroup.styl
@@ -5,7 +5,7 @@
   margin-left 5px
   margin-top 52px
   top 0
-  bottom 0
+  max-height calc(100vh - 52px)
   overflow-y scroll
 
   .s-info-panel-buttons

--- a/web_client/templates/regionWidget.pug
+++ b/web_client/templates/regionWidget.pug
@@ -4,5 +4,6 @@ block input
   .input-group
     +input(title, type, id, value.join(','))
     span.input-group-btn
-      button.btn.btn-default.s-select-region-button(type='button')
+      button.btn.btn-default.s-select-region-button(
+        type='button', data-toggle='tooltip', data-placement='right', title='Draw a region on the image')
         i.icon-pencil

--- a/web_client/templates/regionWidget.pug
+++ b/web_client/templates/regionWidget.pug
@@ -1,0 +1,8 @@
+extends ./widget.pug
+
+block input
+  .input-group
+    +input(title, type, id, value.join(','))
+    span.input-group-btn
+      button.btn.btn-default.s-select-region-button(type='button')
+        i.icon-pencil

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -51,7 +51,7 @@ var ControlWidget = View.extend({
     change: function () {
         events.trigger('s:widgetChanged:' + this.model.get('type'), this.model);
         events.trigger('s:widgetChanged', this.model);
-        this.render();
+        this.render.apply(this, arguments);
     },
 
     remove: function () {

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 
 import View from 'girder/views/View';
+import events from 'girder/events';
 
 import ItemSelectorWidget from './ItemSelectorWidget';
 
@@ -25,9 +26,12 @@ var ControlWidget = View.extend({
     },
 
     initialize: function () {
-        this.listenTo(this.model, 'change', this.render);
+        this.listenTo(this.model, 'change', this.change);
         this.listenTo(this.model, 'destroy', this.remove);
         this.listenTo(this.model, 'invalid', this.invalid);
+        this.listenTo(events, 's:widgetSet:' + this.model.id, (value) => {
+            this.model.set('value', value);
+        });
     },
 
     render: function (_, options) {
@@ -42,7 +46,15 @@ var ControlWidget = View.extend({
         return this;
     },
 
+    change: function () {
+        events.trigger('s:widgetChanged:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetChanged', this.model);
+        this.render();
+    },
+
     remove: function () {
+        events.trigger('s:widgetRemoved:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetRemoved', this.model);
         this.$('.s-control-item[data-type="color"] .input-group').colorpicker('destroy');
         this.$('.s-control-item[data-type="range"] input').slider('destroy');
         this.$el.empty();
@@ -53,6 +65,8 @@ var ControlWidget = View.extend({
      * is invalid.  This is automatically triggered by the model's "invalid" event.
      */
     invalid: function () {
+        events.trigger('s:widgetInvalid:' + this.model.get('type'), this.model);
+        events.trigger('s:widgetInvalid', this.model);
         this.$('.form-group').addClass('has-error');
     },
 

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -10,6 +10,7 @@ import colorWidget from '../templates/colorWidget.pug';
 import enumerationWidget from '../templates/enumerationWidget.pug';
 import fileWidget from '../templates/fileWidget.pug';
 import rangeWidget from '../templates/rangeWidget.pug';
+import regionWidget from '../templates/regionWidget.pug';
 import widget from '../templates/widget.pug';
 
 import '../stylesheets/controlWidget.styl';
@@ -22,7 +23,8 @@ var ControlWidget = View.extend({
     events: {
         'change input,select': '_input',
         'changeColor': '_input',
-        'click .s-select-file-button': '_selectFile'
+        'click .s-select-file-button': '_selectFile',
+        'click .s-select-region-button': '_selectRegion'
     },
 
     initialize: function () {
@@ -117,6 +119,9 @@ var ControlWidget = View.extend({
         },
         'new-file': {
             template: fileWidget
+        },
+        region: {
+            template: regionWidget
         }
     },
 
@@ -164,6 +169,14 @@ var ControlWidget = View.extend({
         modal.once('g:saved', () => {
             modal.$el.modal('hide');
         }).render();
+    },
+
+    /**
+     * Trigger a global event to initiate rectangle drawing mode to whoever
+     * might be listening.
+     */
+    _selectRegion: function () {
+        events.trigger('s:widgetDrawRegion', this.model);
     }
 });
 

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -45,6 +45,7 @@ var ControlWidget = View.extend({
         this.$el.html(this.template()(this.model.attributes));
         this.$('.s-control-item[data-type="range"] input').slider();
         this.$('.s-control-item[data-type="color"] .input-group').colorpicker({});
+        this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});
         return this;
     },
 

--- a/web_client/views/ControlsPanel.js
+++ b/web_client/views/ControlsPanel.js
@@ -20,6 +20,7 @@ var ControlsPanel = Panel.extend({
             id: this.$el.attr('id')
         }));
         this.addAll();
+        this.$('.s-panel-content').collapse({toggle: false});
     },
 
     addOne: function (model) {

--- a/web_client/views/Panel.js
+++ b/web_client/views/Panel.js
@@ -14,6 +14,7 @@ var Panel = View.extend({
     },
     render: function () {
         this.$el.html(panel(this.spec));
+        this.$('.s-panel-content').collapse({toggle: false});
     },
     expand: function () {
         this.$('.icon-down-open').attr('class', 'icon-up-open');
@@ -23,7 +24,7 @@ var Panel = View.extend({
     },
     _handleTitleClick: function (e) {
         if (!$(e.target).hasClass('s-remove-panel')) {
-            e.stopPropagation();
+            e.stopImmediatePropagation();
             this.$('.s-panel-content').collapse('toggle');
         }
     }

--- a/web_client/views/PanelGroup.js
+++ b/web_client/views/PanelGroup.js
@@ -196,6 +196,10 @@ var PanelGroup = View.extend({
      * and cause submissions to post to `path + '/run'`.
      */
     setAnalysis: function (path) {
+        if (!path) {
+            this.reset();
+            return $.when();
+        }
         return restRequest({
             path: path + '/xmlspec',
             dataType: 'xml'


### PR DESCRIPTION
This builds on both #30 and #31 to support the `region` type as a new widget type.  The user can enter the bounding box manually or click on the button to draw a region on the image.