### PR TITLE
Fix an issue with cherrypy >=8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ compiler:
 
 before_install:
     
-    - GIRDER_VERSION=2dc524f1f86f22c0cda248164021a3a8218556be
-    - GIRDER_WORKER_VERSION=f834d4d3701df7f6f3f64fcd7d3f22d15b3b1db2
+    - GIRDER_VERSION=master
+    - GIRDER_WORKER_VERSION=master
     - main_path=$PWD
     - build_path=$PWD/build
     - mkdir -p $build_path
@@ -31,7 +31,8 @@ before_install:
     - girder_worker_path=$girder_path/plugins/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install -U -r $girder_worker_path/requirements.txt -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
+    - pip install -U -r $girder_worker_path/requirements.txt 
+    - pip install -U -r $girder_worker_path/girder_worker/plugins/girder_io/requirements.txt
 
     - export MONGO_VERSION=2.6.11
     - export PY_COVG="ON"
@@ -58,9 +59,10 @@ before_install:
 
 install:
     # https://github.com/pypa/pip/issues/2751
-    - conda install --yes setuptools==19.4 ctk-cli==1.3.1
+    - conda install --yes 'setuptools>=19.4' ctk-cli==1.3.1
     - cd $girder_path
-    - pip install -U -e . -r requirements.txt -r requirements-dev.txt -r $main_path/requirements.txt setuptools==19.4
+    - pip install -r requirements-dev.txt -e .[plugins] 
+    - pip install -r $main_path/requirements.txt 
     - npm-install-retry
     - BABEL_ENV=cover girder-install web --plugins=slicer_cli_web,worker,jobs --dev
 

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import six
 import subprocess
 import tempfile
 
@@ -801,6 +802,8 @@ def genHandlerToGetDockerCLIXmlSpec(cliRelPath, cliXML,
     """
 
     str_xml = cliXML
+    if isinstance(str_xml, six.text_type):
+        str_xml = str_xml.encode('utf8')
 
     # define the handler that returns the CLI's xml spec
     @boundHandler(restResource)


### PR DESCRIPTION
An error was thrown getting the xmlspec for a CLI.  We need to emit raw bytes, not a unicode string.

See CherryPy issue #1489, which was added in CherryPy 8.0.0.  This update is required now that Girder is no longer using CherryPy < 8.

Test using girder master.