### PR TITLE
Remove containers when they stop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,11 +55,9 @@ before_install:
     - bash $build_path/install_miniconda.sh -b -p $build_path/miniconda
     - source $build_path/miniconda/bin/activate $build_path/miniconda
     - conda update --yes --all 'python<=2.7.12'
-    - conda config --add channels https://conda.binstar.org/cdeepakroy
 
 install:
-    # https://github.com/pypa/pip/issues/2751
-    - conda install --yes 'setuptools>=19.4' ctk-cli==1.3.1
+    - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'
     - cd $girder_path
     - pip install -r requirements-dev.txt -e .[plugins] 
     - pip install -r $main_path/requirements.txt 

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -1053,7 +1053,9 @@ def genRESTEndPointsForSlicerCLIsInDockerCache(restResource, dockerCache):
 
 
 def getDockerImage(imageName, pullIfNotExist=False):
-    """checks the local docker cache for the image
+    """
+    Checks the local docker cache for the image
+
     :param imageName: the docker image name in the form of repo/name:tag
     if the tag is not given docker defaults to using the :latest tag
     :type imageName: string
@@ -1095,7 +1097,7 @@ def getDockerImageCLIList(imageName):
         # docker inspect returns non zero if the image is not available
         # locally
         data = subprocess.check_output(
-            ['docker', 'run', imageName, '--list_cli'])
+            ['docker', 'run', '--rm', imageName, '--list_cli'])
         return data
     except subprocess.CalledProcessError:
         # the image does not exist locally, try to pull from dockerhub
@@ -1110,7 +1112,7 @@ def getDockerImageCLIXMLSpec(img, cli):
 
     """
     try:
-        data = subprocess.check_output(['docker', 'run', img, cli, '--xml'])
+        data = subprocess.check_output(['docker', 'run', '--rm', img, cli, '--xml'])
         return data
     except subprocess.CalledProcessError:
         # the image does not exist locally, try to pull from dockerhub


### PR DESCRIPTION
Otherwise, querying for clis ends up creating many containers that don't get cleaned up.