### PR TITLE
Support dropdowns in panels

### DIFF
--- a/web_client/stylesheets/panel.styl
+++ b/web_client/stylesheets/panel.styl
@@ -1,7 +1,7 @@
 .s-panel-group
 
   .s-panel
-    background-color #ffffff
+    background-color rgba(255,255,255,0.95)
     margin-top 5px
     border-radius 3px
     height auto

--- a/web_client/stylesheets/panel.styl
+++ b/web_client/stylesheets/panel.styl
@@ -2,7 +2,6 @@
 
   .s-panel
     background-color #ffffff
-    opacity .95
     margin-top 5px
     border-radius 3px
     height auto
@@ -10,7 +9,6 @@
 
   .s-panel-content
     margin 5px
-    overflow hidden
 
   .s-panel-content:empty
     margin 0

--- a/web_client/templates/panelGroup.pug
+++ b/web_client/templates/panelGroup.pug
@@ -8,6 +8,7 @@ if info
       .s-info-panel-buttons
         button.btn.btn-default.s-info-panel-reload Reload
         button.btn.btn-primary.s-info-panel-submit Submit
+      .clearfix
 
   .s-jobs-panel.s-panel
 


### PR DESCRIPTION
This makes it possible to use dropdowns in panels that can overflow the extent of the panel.  It requires turning off the (very slight) opacity on the panels to avoid creating a new stacking context for each panel.  The difference is mostly not noticeable.