### PR TITLE
Support partially valid CLIs.

### DIFF
--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -224,10 +224,7 @@ class DockerImageManagementTest(base.TestCase):
         for cli in absent:
             self.assertHasKeys(data, [userAndRepo])
             self.assertHasKeys(data[userAndRepo], [tag])
-            self.assertHasKeys(data[userAndRepo][tag], [cli])
-            path = data[userAndRepo][tag][cli]['xmlspec']
-            resp = self.request(path=path, user=self.admin)
-            self.assertStatus(resp, 404)
+            self.assertNotHasKeys(data[userAndRepo][tag], [cli])
 
     def getEndpoint(self):
         resp = self.request(path='/slicer_cli_web/slicer_cli_web/docker_image',

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -209,7 +209,8 @@ class DockerImageManagementTest(base.TestCase):
 
         :param name: name of the image used to determine endpoint location.
         :param present: a list of endpoints within the image that must exist.
-        :param absent: a list of endpoints that should not be in the image.
+        :param absent: a list of endpoints that should be in the image but not
+            have endpoints.
         """
         userAndRepo, tag = self.splitName(name)
         data = self.getEndpoint()
@@ -221,10 +222,12 @@ class DockerImageManagementTest(base.TestCase):
             resp = self.request(path=path, user=self.admin, isJson=False)
             self.assertStatusOk(resp)
         for cli in absent:
-            if userAndRepo in data and tag in data[userAndRepo] and cli in data[userAndRepo][tag]:
-                path = data[userAndRepo][tag][cli]['xmlspec']
-                resp = self.request(path=path, user=self.admin)
-                self.assertStatus(resp, 404)
+            self.assertHasKeys(data, [userAndRepo])
+            self.assertHasKeys(data[userAndRepo], [tag])
+            self.assertHasKeys(data[userAndRepo][tag], [cli])
+            path = data[userAndRepo][tag][cli]['xmlspec']
+            resp = self.request(path=path, user=self.admin)
+            self.assertStatus(resp, 404)
 
     def getEndpoint(self):
         resp = self.request(path='/slicer_cli_web/slicer_cli_web/docker_image',

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -77,6 +77,7 @@ class DockerImageManagementTest(base.TestCase):
         self.assertNoImages()
         self.addImage(img_name, JobStatus.SUCCESS)
         self.imageIsLoaded(img_name, True)
+        self.endpointsExist(img_name, ['Example1', 'Example2'], ['Example3'])
 
     def testDockerAddList(self):
         # try to cache a good image to the mongo database
@@ -157,7 +158,6 @@ class DockerImageManagementTest(base.TestCase):
                     self.assertNotEqual(xmlString, '')
 
     def testEndpointDeletion(self):
-
         img_name = 'girder/slicer_cli_web:small'
         self.testXmlEndpoint()
         data = self.getEndpoint()
@@ -190,7 +190,6 @@ class DockerImageManagementTest(base.TestCase):
         return imageAndTag[0], imageAndTag[1]
 
     def imageIsLoaded(self, name, exists):
-
         userAndRepo, tag = self.splitName(name)
 
         data = self.getEndpoint()
@@ -204,8 +203,30 @@ class DockerImageManagementTest(base.TestCase):
             imgVersions = data[userAndRepo]
             self.assertHasKeys(imgVersions, [tag])
 
-    def getEndpoint(self):
+    def endpointsExist(self, name, present=[], absent=[]):
+        """
+        Test if endpoints for particular image exist.
 
+        :param name: name of the image used to determine endpoint location.
+        :param present: a list of endpoints within the image that must exist.
+        :param absent: a list of endpoints that should not be in the image.
+        """
+        userAndRepo, tag = self.splitName(name)
+        data = self.getEndpoint()
+        for cli in present:
+            self.assertHasKeys(data, [userAndRepo])
+            self.assertHasKeys(data[userAndRepo], [tag])
+            self.assertHasKeys(data[userAndRepo][tag], [cli])
+            path = data[userAndRepo][tag][cli]['xmlspec']
+            resp = self.request(path=path, user=self.admin, isJson=False)
+            self.assertStatusOk(resp)
+        for cli in absent:
+            if userAndRepo in data and tag in data[userAndRepo] and cli in data[userAndRepo][tag]:
+                path = data[userAndRepo][tag][cli]['xmlspec']
+                resp = self.request(path=path, user=self.admin)
+                self.assertStatus(resp, 404)
+
+    def getEndpoint(self):
         resp = self.request(path='/slicer_cli_web/slicer_cli_web/docker_image',
                             user=self.admin)
         self.assertStatus(resp, 200)
@@ -214,12 +235,12 @@ class DockerImageManagementTest(base.TestCase):
     def assertNoImages(self):
         data = self.getEndpoint()
         self.assertEqual({}, data,
-                         ' There should be no pre existing docker images ')
+                         'There should be no pre existing docker images')
 
     def deleteImage(self, name, responseCodeOK, deleteDockerImage=False,
                     status=4):
         """
-        delete docker image data and test whether a docker
+        Delete docker image data and test whether a docker
         image can be deleted off the local machine
         """
         job_status = [JobStatus.SUCCESS]

--- a/small-docker/Example3/Example3.py
+++ b/small-docker/Example3/Example3.py
@@ -1,0 +1,10 @@
+import pprint
+from ctk_cli import CLIArgumentParser
+
+
+def main(args):
+    print('>> parsed arguments')
+    pprint.pprint(vars(args))
+
+if __name__ == "__main__":
+    main(CLIArgumentParser().parse_args())

--- a/small-docker/Example3/Example3.xml
+++ b/small-docker/Example3/Example3.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<executable>
+  <category>Example</category>
+  <title>Example with missing default</title>
+  <description>This wil lfail to create a REST endpoint, but it still will report that it exists as a CLI.</description>
+  <version>0.1.0</version>
+  <license>Apache 2.0</license>
+  <contributor>David Manthey (Kitware)</contributor>
+  <parameters>
+    <label>IO</label>
+    <description>Input/output parameters.</description>
+    <float>
+      <name>x</name>
+      <label>Coordinate</label>
+      <description>A floating point number between 0 and 1</description>
+      <channel>input</channel>
+      <constraints>
+        <minimum>0</minimum>
+        <maximum>1</maximum>
+      </constraints>
+    </float>
+  </parameters>
+</executable>

--- a/small-docker/Example3/Example3.xml
+++ b/small-docker/Example3/Example3.xml
@@ -2,7 +2,7 @@
 <executable>
   <category>Example</category>
   <title>Example with missing default</title>
-  <description>This wil lfail to create a REST endpoint, but it still will report that it exists as a CLI.</description>
+  <description>This will fail to create a REST endpoint, but it still will report that it exists as a CLI.</description>
   <version>0.1.0</version>
   <license>Apache 2.0</license>
   <contributor>David Manthey (Kitware)</contributor>
@@ -12,6 +12,7 @@
     <float>
       <name>x</name>
       <label>Coordinate</label>
+      <flag>x</flag>
       <description>A floating point number between 0 and 1</description>
       <channel>input</channel>
       <constraints>

--- a/small-docker/cli_list.json
+++ b/small-docker/cli_list.json
@@ -4,5 +4,8 @@
   },
   "Example2": {
     "type": "python"
+  },
+  "Example3": {
+    "type": "python"
   }
 }


### PR DESCRIPTION
If a CLI can return xml for its commands, but some of those commands cannot be made into valid endpoints, still generate endpoints for valid commands.

Otherwise, the failure to generate an endpoint prevents ANY cli in the system from being listed.

Make some of the formatting more consistent and clean up some text.

For testing, update the small docker image with an example that is missing a default.