### PR TITLE
When adding images, return the job that was created.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 install:
     - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'
     - cd $girder_path
-    - pip install -r requirements-dev.txt -e .[plugins] 
+    - pip install -r requirements-dev.txt -e .[worker] 
     - pip install -r $main_path/requirements.txt 
     - npm-install-retry
     - BABEL_ENV=cover girder-install web --plugins=slicer_cli_web,worker,jobs --dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker-py==1.9.0
-six==1.10.0
-jsonschema==2.5.1
+docker>=2
+six>=1.10.0
+jsonschema>=2.5.1

--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -105,5 +105,6 @@ def CLIListEntrypoint(cli_list_spec_file=None):
             cli_list_spec[args.cli]['type']
         )
 
+
 if __name__ == "__main__":
     CLIListEntrypoint()

--- a/server/models/docker_image.py
+++ b/server/models/docker_image.py
@@ -59,7 +59,7 @@ class DockerImage():
     type = 'type'
     xml = 'xml'
     cli_dict = 'cli_list'
-    # structure of the dictionary to store meta data
+    # structure of the dictionary to store metadata
     # {
     # imagehash:<hash of docker image name>
     #     cli_list: {
@@ -118,7 +118,7 @@ class DockerImage():
     def getHashKey(imgName):
         """
         Generates a hash key (on the docker image name) used by the DockerImage
-         object to provide a means to uniquely find the image meta data
+         object to provide a means to uniquely find the image metadata
          in the girder-mongo database. This prevents user defined image name
          from causing issues with pymongo.Note this key is not the same as the
          docker image id that the docker engine generates
@@ -161,7 +161,7 @@ class DockerImage():
 
 class DockerCache:
     """
-    This class is used to hold and access meta data on existing images
+    This class is used to hold and access metadata on existing images
     """
     def __init__(self):
         """

--- a/server/models/docker_image_model.py
+++ b/server/models/docker_image_model.py
@@ -62,14 +62,15 @@ class DockerImageModel(AccessControlledModel):
         """
         Attempts to cache metadata on the docker images listed in the names
         list.
-        If the pullIfNotLocal flag is true, the job will attempt to pull
-         the image if it does not exist.
-        :param names: A list of docker image names(can use with tags or digests)
-        :param jobType: defines the jobtype of the job that will be schedueled
-         ,used by event listeners to determine if a job succeeded or not
-         :param pullIfNotLocal: Boolean to determine whether a non existent
-         image
-         should be pulled,(attempts to pull from default docker hub registry)
+
+        :param names: A list of docker image names (can use with tags or
+            digests)
+        :param jobType: defines the jobtype of the job that will be schedueled.
+            This can be used by event listeners to determine if a job succeeds.
+        :param pullIfNotLocal: Boolean if True, the job will attempt to pull
+            the image from the default docker hub registry if it does not
+            exist.
+        :returns: the job that was created.
         """
         jobModel = ModelImporter.model('job', 'jobs')
         # list of images to pull and load
@@ -111,6 +112,7 @@ class DockerImageModel(AccessControlledModel):
         )
 
         jobModel.scheduleJob(job)
+        return job
 
     def _ImageExistsLocally(self, name):
         """

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -597,6 +597,7 @@ def genHandlerToRunDockerCLI(dockerImage, cliRelPath, cliXML, restResource):
     -------
     function
         Returns a function that runs the CLI using girder_worker
+
     """
 
     cliName = os.path.normpath(cliRelPath).replace(os.sep, '.')
@@ -778,8 +779,7 @@ def genHandlerToRunDockerCLI(dockerImage, cliRelPath, cliXML, restResource):
     return handlerFunc
 
 
-def genHandlerToGetDockerCLIXmlSpec(cliRelPath, cliXML,
-                                    restResource):
+def genHandlerToGetDockerCLIXmlSpec(cliRelPath, cliXML, restResource):
     """Generates a handler that returns the XML spec of the docker CLI
 
     Parameters
@@ -799,6 +799,7 @@ def genHandlerToGetDockerCLIXmlSpec(cliRelPath, cliXML,
     -------
     function
         Returns a function that returns the xml spec of the CLI
+
     """
 
     str_xml = cliXML
@@ -839,10 +840,6 @@ def genRESTEndPointsForSlicerCLIsInDocker(info, restResource, dockerImages):
     restResource : str or girder.api.rest.Resource
         REST resource to which the end-points should be attached
     dockerImages : a list of docker image names
-
-
-    Returns
-    -------
 
     """
     dockerImages
@@ -968,14 +965,9 @@ def genRESTEndPointsForSlicerCLIsInDockerCache(restResource, dockerCache):
 
     Parameters
     ----------
-
     restResource : a dockerResource
         REST resource to which the end-points should be attached
     dockerCache : DockerCache object representing data stored in settings
-
-
-    Returns
-    -------
 
     """
 


### PR DESCRIPTION
This allows callers to know the specific job ID, rather than just binding to an event and handling all slicer_cli_web jobs.

Also, allow a single image name to be specified for PUT or DELETE without quotes around it.