### PR TITLE
Look for c++ slicer CLIS in PATH if not in CLI source dir

### DIFF
--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -94,8 +94,15 @@ def CLIListEntrypoint(cli_list_spec_file=None):
 
         script_file = os.path.join('.', args.cli, os.path.basename(args.cli))
 
-        # ./<cli-rel-path>/<cli-name> [<args>]
-        subprocess.call([script_file] + sys.argv[2:])
+        if os.path.isfile(script_file):
+
+            # ./<cli-rel-path>/<cli-name> [<args>]
+            subprocess.call([script_file] + sys.argv[2:])
+
+        else:
+
+            # assumes parent dir of CLI executable is in ${PATH}
+            subprocess.call([os.path.basename(args.cli)] + sys.argv[2:])
 
     else:
         logger.exception('CLIs of type %s are not supported',


### PR DESCRIPTION
This PR modified `cli_list_entrypoint.py` to expect the executables of C++ CLIs to be in ${PATH} if they are not found in CLI's source dir.

This is to expose the Slicer CLIs of TubeTK which puts all CLI executables in a single `bin` directory.