### PR TITLE
Assume parameters are input unless explicitly specified as output

### DIFF
--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -545,7 +545,7 @@ def _addIndexedParamsToContainerArgs(index_params, containerArgs, hargs):
 
     for param in index_params:
 
-        if param.channel == 'input':
+        if param.channel != 'output':
 
             if _is_on_girder(param):
                 curValue = "$input{%s}" % param.identifier()
@@ -555,7 +555,7 @@ def _addIndexedParamsToContainerArgs(index_params, containerArgs, hargs):
                     hargs['params'][param.identifier()]
                 )
 
-        elif param.channel == 'output':
+        else:
 
             if not _is_on_girder(param):
                 raise Exception(
@@ -570,9 +570,6 @@ def _addIndexedParamsToContainerArgs(index_params, containerArgs, hargs):
                 _worker_docker_data_dir,
                 hargs['params'][param.identifier() + _girderOutputNameSuffix]
             )
-
-        else:
-            continue
 
         containerArgs.append(curValue)
 
@@ -637,7 +634,7 @@ def genHandlerToRunDockerCLI(dockerImage, cliRelPath, cliXML, restResource):
     index_params, opt_params, simple_out_params = _getCLIParameters(clim)
 
     # add indexed input parameters
-    index_input_params = filter(lambda p: p.channel == 'input', index_params)
+    index_input_params = filter(lambda p: p.channel != 'output', index_params)
 
     _addIndexedInputParamsToHandler(index_input_params, handlerDesc)
 


### PR DESCRIPTION
According to the [SlicerExecutionModel XML schema documentation](https://www.slicer.org/wiki/Documentation/Nightly/Developers/SlicerExecutionModel#XML_Schema), the `<channel>` parameter is only "required for file, pointfile, directory and image parameters". Examples make it clear that `<channel>input</channel>` is the intended default.

`slicer_cli_web` is currently too strict, requiring specifying the channel for all index parameters, regardless of type. This PR brings it to the other side, letting any parameter leave its channel unspecified for a default of `input`. This already appears to be the behavior for optional parameters.