### PR TITLE
Fix optional output params typo

### DIFF
--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -729,7 +729,7 @@ def genHandlerToRunDockerCLI(dockerImage, cliRelPath, cliXML, restResource):
         _addOptionalInputParamsToContainerArgs(opt_input_params,
                                                containerArgs, hargs)
 
-        _addOptionalOutputParamsToContainerArgs(opt_input_params,
+        _addOptionalOutputParamsToContainerArgs(opt_output_params,
                                                 containerArgs, kwargs, hargs)
 
         _addReturnParameterFileToContainerArgs(containerArgs, kwargs, hargs)


### PR DESCRIPTION
Optional file output params are not being properly passed to the CLIs due to a typo (cf. the problem testing here: https://github.com/girder/slicer_cli_web/pull/43#issue-229790358). This PR changes that to pass the right variable.