### PR TITLE
Support Girder items and files as distinct types.

### DIFF
--- a/plugin_tests/widgetSpec.js
+++ b/plugin_tests/widgetSpec.js
@@ -21,6 +21,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', '0.5');
         expect(w.value()).toBe(0.5);
@@ -49,6 +50,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', '0.5');
         expect(w.value()).toBe(0.5);
@@ -90,6 +92,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         expect(w.value()).toBe(false);
         expect(w.isValid()).toBe(true);
@@ -110,6 +113,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         expect(w.value()).toBe('Default value');
         expect(w.isValid()).toBe(true);
@@ -129,6 +133,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(true);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', '#ffffff');
         expect(w.value()).toBe('#ffffff');
@@ -157,6 +162,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', 'a,b,c');
         expect(w.value()).toEqual(['a', 'b', 'c']);
@@ -177,6 +183,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', 'a,b,c');
         expect(w.isValid()).toBe(false);
@@ -208,6 +215,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(true);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', 'value 1');
         expect(w.isValid()).toBe(true);
@@ -234,6 +242,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(true);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         w.set('value', '11');
         expect(w.isValid()).toBe(true);
@@ -255,6 +264,20 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(true);
+        expect(w.isItem()).toBe(false);
+    });
+    it('item', function () {
+        var w = new slicer.models.WidgetModel({
+            type: 'item',
+            title: 'Item widget'
+        });
+        expect(w.isNumeric()).toBe(false);
+        expect(w.isBoolean()).toBe(false);
+        expect(w.isVector()).toBe(false);
+        expect(w.isColor()).toBe(false);
+        expect(w.isEnumeration()).toBe(false);
+        expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(true);
     });
     it('invalid', function () {
         var w = new slicer.models.WidgetModel({
@@ -267,6 +290,7 @@ describe('widget model', function () {
         expect(w.isColor()).toBe(false);
         expect(w.isEnumeration()).toBe(false);
         expect(w.isFile()).toBe(false);
+        expect(w.isItem()).toBe(false);
 
         expect(w.isValid()).toBe(false);
     });
@@ -285,7 +309,9 @@ describe('widget collection', function () {
             {type: 'string-enumeration', id: 'string-enumeration', values: ['a'], value: 'a'},
             {type: 'number-enumeration', id: 'number-enumeration', values: [1], value: '1'},
             {type: 'file', id: 'file', value: new Backbone.Model({id: 'a'})},
-            {type: 'new-file', id: 'new-file', value: new Backbone.Model({name: 'a', folderId: 'b'})}
+            {type: 'new-file', id: 'new-file', value: new Backbone.Model({name: 'a', folderId: 'b'})},
+            {type: 'item', id: 'item', value: new Backbone.Model({id: 'c'})},
+            {type: 'image', id: 'image', value: new Backbone.Model({id: 'd'})}
         ]);
 
         expect(c.values()).toEqual({
@@ -298,9 +324,11 @@ describe('widget collection', function () {
             'number-vector': '[1,2,3]',
             'string-enumeration': '"a"',
             'number-enumeration': '1',
-            'file_girderItemId': 'a',
+            'file_girderFileId': 'a',
             'new-file_girderFolderId': 'b',
-            'new-file_name': 'a'
+            'new-file_name': 'a',
+            'item_girderItemId': 'c',
+            'image_girderFileId': 'd'
         });
     });
 });
@@ -539,8 +567,38 @@ describe('control widget view', function () {
         expect(w.model.value()).toBe(300);
     });
 
-    it('file', function () {
+    it('item', function () {
         var arg, item = new girder.models.ItemModel({id: 'model id', name: 'b'});
+
+        hProto.initialize = function (_arg) {
+            arg = _arg;
+            this.breadcrumbs = [];
+        };
+        hProto.render = function () {};
+
+        var w = new slicer.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new slicer.models.WidgetModel({
+                type: 'item',
+                title: 'Title',
+                id: 'item-widget'
+            })
+        });
+
+        w.render();
+        checkWidgetCommon(w);
+
+        w.$('.s-select-file-button').click();
+        expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
+        arg.onItemClick(item);
+        expect(w.model.value().name()).toBe('b');
+
+        expect(w.model.get('path')).toEqual([]);
+    });
+
+    it('file', function (done) {
+        var arg, file = new girder.models.FileModel({id: 'model id', name: 'd'});
 
         hProto.initialize = function (_arg) {
             arg = _arg;
@@ -561,12 +619,58 @@ describe('control widget view', function () {
         w.render();
         checkWidgetCommon(w);
 
+        girder.rest.mockRestRequest(function () {
+            return $.Deferred().resolve(JSON.stringify(file)).promise();
+        });
+        hProto.on('g:saved', function () {
+            console.log('here');
+            expect(w.model.value().name()).toBe('d');
+
+            expect(w.model.get('path')).toEqual([]);
+            girder.rest.unmockRestRequest();
+            done();
+        });
         w.$('.s-select-file-button').click();
         expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
-        arg.onItemClick(item);
-        expect(w.model.value().name()).toBe('b');
+        arg.onItemClick(file);
+    });
 
-        expect(w.model.get('path')).toEqual([]);
+    it('image', function (done) {
+        var arg, file = new girder.models.FileModel({id: 'model id', name: 'e'});
+
+        hProto.initialize = function (_arg) {
+            arg = _arg;
+            this.breadcrumbs = [];
+        };
+        hProto.render = function () {};
+
+        var w = new slicer.views.ControlWidget({
+            parentView: parentView,
+            el: $el.get(0),
+            model: new slicer.models.WidgetModel({
+                type: 'image',
+                title: 'Title',
+                id: 'image-widget'
+            })
+        });
+
+        w.render();
+        checkWidgetCommon(w);
+
+        girder.rest.mockRestRequest(function () {
+            return $.Deferred().resolve(JSON.stringify(file)).promise();
+        });
+        hProto.on('g:saved', function () {
+            console.log('here');
+            expect(w.model.value().name()).toBe('e');
+
+            expect(w.model.get('path')).toEqual([]);
+            girder.rest.unmockRestRequest();
+            done();
+        });
+        w.$('.s-select-file-button').click();
+        expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
+        arg.onItemClick(file);
     });
 
     it('new-file', function () {

--- a/plugin_tests/widgetSpec.js
+++ b/plugin_tests/widgetSpec.js
@@ -597,80 +597,91 @@ describe('control widget view', function () {
         expect(w.model.get('path')).toEqual([]);
     });
 
-    it('file', function (done) {
-        var arg, file = new girder.models.FileModel({id: 'model id', name: 'd'});
+    it('file', function () {
+        var arg, file, item, w;
+        runs(function () {
+            item = new girder.models.ItemModel({_id: 'item id', name: 'd'});
+            file = new girder.models.FileModel({_id: 'file id', name: 'e'});
 
-        hProto.initialize = function (_arg) {
-            arg = _arg;
-            this.breadcrumbs = [];
-        };
-        hProto.render = function () {};
+            hProto.initialize = function (_arg) {
+                arg = _arg;
+                this.breadcrumbs = [];
+            };
+            hProto.render = function () {};
+            w = new slicer.views.ControlWidget({
+                parentView: parentView,
+                el: $el.get(0),
+                model: new slicer.models.WidgetModel({
+                    type: 'file',
+                    title: 'Title',
+                    id: 'file-widget'
+                })
+            });
 
-        var w = new slicer.views.ControlWidget({
-            parentView: parentView,
-            el: $el.get(0),
-            model: new slicer.models.WidgetModel({
-                type: 'file',
-                title: 'Title',
-                id: 'file-widget'
-            })
+            w.render();
+            checkWidgetCommon(w);
+
+            girder.rest.mockRestRequest(function (opts) {
+                if (opts.path.substr(0, 5) === 'file/') {
+                    return $.Deferred().resolve(file.toJSON());
+                }
+                return $.Deferred().resolve([file.toJSON()]);
+            });
+            w.$('.s-select-file-button').click();
+            expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
+            arg.onItemClick(item);
         });
-
-        w.render();
-        checkWidgetCommon(w);
-
-        girder.rest.mockRestRequest(function () {
-            return $.Deferred().resolve(JSON.stringify(file)).promise();
+        waitsFor(function () {
+            return w.model.value().name() === 'e';
         });
-        hProto.on('g:saved', function () {
-            console.log('here');
-            expect(w.model.value().name()).toBe('d');
-
+        runs(function () {
+            expect(w.model.value().name()).toBe('e');
             expect(w.model.get('path')).toEqual([]);
             girder.rest.unmockRestRequest();
-            done();
         });
-        w.$('.s-select-file-button').click();
-        expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
-        arg.onItemClick(file);
     });
 
     it('image', function (done) {
-        var arg, file = new girder.models.FileModel({id: 'model id', name: 'e'});
+        var arg, item, file, w;
+        runs(function () {
+            file = new girder.models.FileModel({_id: 'file id', name: 'g'});
+            item = new girder.models.ItemModel({
+                _id: 'item id', name: 'f', largeImage: {fileId: file.id}});
 
-        hProto.initialize = function (_arg) {
-            arg = _arg;
-            this.breadcrumbs = [];
-        };
-        hProto.render = function () {};
+            hProto.initialize = function (_arg) {
+                arg = _arg;
+                this.breadcrumbs = [];
+            };
+            hProto.render = function () {};
 
-        var w = new slicer.views.ControlWidget({
-            parentView: parentView,
-            el: $el.get(0),
-            model: new slicer.models.WidgetModel({
-                type: 'image',
-                title: 'Title',
-                id: 'image-widget'
-            })
+            w = new slicer.views.ControlWidget({
+                parentView: parentView,
+                el: $el.get(0),
+                model: new slicer.models.WidgetModel({
+                    type: 'image',
+                    title: 'Title',
+                    id: 'image-widget'
+                })
+            });
+
+            w.render();
+            checkWidgetCommon(w);
+
+            girder.rest.mockRestRequest(function (opts) {
+                return $.Deferred().resolve(file.toJSON());
+            });
+            w.$('.s-select-file-button').click();
+            expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
+            arg.onItemClick(item);
         });
-
-        w.render();
-        checkWidgetCommon(w);
-
-        girder.rest.mockRestRequest(function () {
-            return $.Deferred().resolve(JSON.stringify(file)).promise();
+        waitsFor(function () {
+            return w.model.value().name() === 'g';
         });
-        hProto.on('g:saved', function () {
-            console.log('here');
-            expect(w.model.value().name()).toBe('e');
-
+        runs(function () {
+            expect(w.model.value().name()).toBe('g');
             expect(w.model.get('path')).toEqual([]);
             girder.rest.unmockRestRequest();
-            done();
         });
-        w.$('.s-select-file-button').click();
-        expect(arg.parentModel).toBe(girder.auth.getCurrentUser());
-        arg.onItemClick(file);
     });
 
     it('new-file', function () {

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -368,12 +368,11 @@ def _createOutputParamBindingSpec(param, hargs, user, token):
                     param.reference, param.identifier())
             )
 
-        curBindingSpec['reference'] = json.dumps(
-            {
-                'itemId': str(hargs[param.reference]['_id']),
-                'userId': str(user['_id'])
-            }
-        )
+        curBindingSpec['reference'] = json.dumps({
+            'itemId': str(hargs[param.reference]['_id']),
+            'userId': str(user['_id']),
+            'identifier': param.identifier()
+        })
 
     return curBindingSpec
 

--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -39,11 +39,13 @@ _SLICER_TO_GIRDER_WORKER_TYPE_MAP = {
 _SLICER_TYPE_TO_GIRDER_MODEL_MAP = {
     'image': 'file',
     'file': 'file',
+    'item': 'item',
     'directory': 'folder'
 }
 _SLICER_TYPE_TO_GIRDER_INPUT_SUFFIX_MAP = {
     'image': '_girderFileId',
-    'file': '_girderItemId',
+    'file': '_girderFileId',
+    'item': '_girderItemId',
     'directory': '_girderFolderId',
 }
 

--- a/web_client/collections/WidgetCollection.js
+++ b/web_client/collections/WidgetCollection.js
@@ -16,6 +16,9 @@ var WidgetCollection = Backbone.Collection.extend({
             // https://github.com/DigitalSlideArchive/slicer/blob/9e5112ab3444ad8c699d70452a5fe4a74ebbc778/server/__init__.py#L44-L46
             switch (m.get('type')) {
                 case 'file':
+                    params[m.id + '_girderFileId'] = m.value().id;
+                    break;
+                case 'item':
                     params[m.id + '_girderItemId'] = m.value().id;
                     break;
                 case 'new-file':

--- a/web_client/models/WidgetModel.js
+++ b/web_client/models/WidgetModel.js
@@ -299,7 +299,7 @@ var WidgetModel = Backbone.Model.extend({
      */
     isGirderModel: function () {
         return _.contains(
-            ['directory', 'file', 'new-file', 'image'],
+            ['directory', 'file', 'item', 'new-file', 'image'],
             this.get('type')
         );
     },
@@ -309,6 +309,13 @@ var WidgetModel = Backbone.Model.extend({
      */
     isFile: function () {
         return this.get('type') === 'file';
+    },
+
+    /**
+     * True if the value represents an item stored in girder.
+     */
+    isItem: function () {
+        return this.get('type') === 'item';
     },
 
     /**
@@ -333,6 +340,7 @@ var WidgetModel = Backbone.Model.extend({
         'number-enumeration',
         'string-enumeration',
         'file',
+        'item',
         'directory',
         'new-file',
         'image',

--- a/web_client/parser/widget.js
+++ b/web_client/parser/widget.js
@@ -21,6 +21,7 @@ function widget(param) {
         region: 'region',
         image: 'image',
         file: 'file',
+        item: 'item',
         directory: 'directory'
     };
     return typeMap[param.tagName];

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -112,6 +112,9 @@ var ControlWidget = View.extend({
         file: {
             template: fileWidget
         },
+        item: {
+            template: fileWidget
+        },
         image: {
             template: fileWidget
         },


### PR DESCRIPTION
Before, we only had a 'file' type which didn't quite emit Girder items properly.  This adds a new 'item' type.  files select the first file in a girder item (this could be changed later), and raise an error if a file-less item is selected.  items return a girder item.  The auto-generated names include either _girderFileId or _girderItemId and actually represent the named model.