### PR TITLE
WIP: Cleanup Backbone code

### DIFF
--- a/web_client/models/WidgetModel.js
+++ b/web_client/models/WidgetModel.js
@@ -25,13 +25,6 @@ var WidgetModel = Backbone.Model.extend({
     },
 
     /**
-     * Sets initial model attributes with normalization.
-     */
-    initialize: function (model) {
-        this.set(_.defaults(model || {}, this.defaults));
-    },
-
-    /**
      * Override Model.set for widget specific bahavior.
      */
     set: function (hash, options) {

--- a/web_client/views/ControlWidget.js
+++ b/web_client/views/ControlWidget.js
@@ -42,7 +42,7 @@ var ControlWidget = View.extend({
         if (options && options.norender) {
             return this;
         }
-        this.$el.html(this.template()(this.model.attributes));  // eslint-disable-line backbone/no-view-model-attributes
+        this.$el.html(this.template()(this.model.toJSON()));
         this.$('.s-control-item[data-type="range"] input').slider();
         this.$('.s-control-item[data-type="color"] .input-group').colorpicker({});
         this.$('[data-toggle="tooltip"]').tooltip({container: 'body'});

--- a/web_client/views/ItemSelectorWidget.js
+++ b/web_client/views/ItemSelectorWidget.js
@@ -35,7 +35,7 @@ var ItemSelectorWidget = View.extend({
         });
 
         this.$el.html(
-            itemSelectorWidget(this.model.attributes)  // eslint-disable-line backbone/no-view-model-attributes
+            itemSelectorWidget(this.model.toJSON())
         ).girderModal(this);
 
         this._hierarchyView.setElement(this.$('.s-hierarchy-widget')).render();


### PR DESCRIPTION
* Remove unnecessary `WidgetModel.initialize` method
  * The default behavior of Backbone models is to set model attributes to values in `defaults`.
  * See: http://backbonejs.org/#Model-defaults
* Pass model attributes to templates without causing ESLint errors