### PR TITLE
When creating a input spec, don't fetch the parent.

### DIFF
--- a/server/rest_slicer_cli.py
+++ b/server/rest_slicer_cli.py
@@ -338,7 +338,7 @@ def _createInputParamBindingSpec(param, hargs, token):
             hargs[param.identifier()],
             resourceType=_SLICER_TYPE_TO_GIRDER_MODEL_MAP[param.typ],
             dataType='string', dataFormat='string',
-            token=token, fetchParent=True)
+            token=token, fetchParent=False)
     else:
         # inputs that are not of type image, file, or directory
         # should be passed inline as string from json.dumps()


### PR DESCRIPTION
This was done when we first started asking for images as files rather than items.  We have the ability to ask for items distinct from files, so if something needs a whole item, it really should ask for it.  Otherwise, for a multi-file item, we end up downloading all of the files, even though only one is asked for.