### PR TITLE
Fix job status in the job panel.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "name": "slicer_cli_web",
     "description": "A girder plugin for exposing slicer CLIs over the web",
     "version": "0.2.0",
-    "dependencies": ["worker"],
+    "dependencies": ["worker", "jobs"],
     "npm": {
         "dependencies": {
             "bootstrap-colorpicker": "2.3.6",


### PR DESCRIPTION
If the jobs plugin is not explicitly referenced in the plugin.json list, then the job panel ends up with a JobStatus that is independent of the main JobStatus in Girder and lacks the worker plugin's added statuses.