### PR TITLE
Use the fileId, not originalId for large images.

### DIFF
--- a/web_client/views/ItemSelectorWidget.js
+++ b/web_client/views/ItemSelectorWidget.js
@@ -98,7 +98,7 @@ var ItemSelectorWidget = View.extend({
                     return;
                 }
 
-                // For now, use the original file id rather than the large image id
+                // Prefer the large_image fileId
                 file = new FileModel({_id: image.fileId || image.originalId});
                 file.once('g:fetched', _.bind(function () {
                     this.model.set({

--- a/web_client/views/ItemSelectorWidget.js
+++ b/web_client/views/ItemSelectorWidget.js
@@ -99,7 +99,7 @@ var ItemSelectorWidget = View.extend({
                 }
 
                 // For now, use the original file id rather than the large image id
-                file = new FileModel({_id: image.originalId || image.fileId});
+                file = new FileModel({_id: image.fileId || image.originalId});
                 file.once('g:fetched', _.bind(function () {
                     this.model.set({
                         path: this._path(),


### PR DESCRIPTION
Before, the CLI was passed the original image, not the large image.  This was a hold over from before CLIs used large image.

large_image specific code should be pulled out of slicer_cli_web and moved to large_image, but until that is done, this fixes the current issue.