### PR TITLE
Include file extension information from slicer xml

### DIFF
--- a/plugin_tests/parseSpec.js
+++ b/plugin_tests/parseSpec.js
@@ -269,7 +269,7 @@ describe('XML Schema parser', function () {
         });
         it('output file', function () {
             var xml = $.parseXML(
-                '<file>' +
+                '<file fileExtensions=".txt">' +
                     '<longflag>foo</longflag>' +
                     '<channel>output</channel>' +
                     '<label>arg1</label>' +
@@ -284,7 +284,8 @@ describe('XML Schema parser', function () {
                 id: 'foo',
                 title: 'arg1',
                 description: 'A description',
-                channel: 'output'
+                channel: 'output',
+                extensions: '.txt'
             });
         });
     });

--- a/web_client/parser/param.js
+++ b/web_client/parser/param.js
@@ -15,6 +15,7 @@ function param(paramTag) {
     var type = widget(paramTag);
     var values = {};
     var channel = $param.find('channel');
+    var extra = {};
 
     if (channel.length) {
         channel = channel.text();
@@ -24,6 +25,7 @@ function param(paramTag) {
 
     if ((type === 'file' || type === 'image') && channel === 'output') {
         type = 'new-file';
+        extra['extensions'] = $param.attr('fileExtensions');
     }
 
     if (!type) {
@@ -49,7 +51,8 @@ function param(paramTag) {
         },
         values,
         defaultValue(type, $param.find('default')),
-        constraints(type, $param.find('constraints').get(0))
+        constraints(type, $param.find('constraints').get(0)),
+        extra
     );
 }
 


### PR DESCRIPTION
The file extensions are passed on to the widget model.  This is done to
support automatically generating a default file name in case one is not
provided.