### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,16 @@ sudo: required
 
 services:
   - docker
+  - rabbitmq
 
 compiler:
     - gcc
+
+addons:
+  apt:
+    packages:
+      # canvas
+      - libgif-dev
 
 before_install:
     # Fix a travis/boto issue.  See
@@ -34,9 +41,9 @@ before_install:
     - girder_worker_path=$girder_path/plugins/girder_worker
     - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
     - cp $PWD/plugin_tests/data/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-    - pip install -U $girder_worker_path
+    - pip install --no-cache-dir -U $girder_worker_path'[girder_io,docker]'
 
-    - export MONGO_VERSION=2.6.11
+    - export MONGO_VERSION=3.2.18
     - export PY_COVG="ON"
     - CACHE=$HOME/.cache source $girder_path/scripts/install_mongo.sh
     - mkdir /tmp/db
@@ -53,11 +60,6 @@ before_install:
     - npm prune
     - npm install -g npm-install-retry
 
-    - wget -O $build_path/install_miniconda.sh https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-    - bash $build_path/install_miniconda.sh -b -p $build_path/miniconda
-    - source $build_path/miniconda/bin/activate $build_path/miniconda
-    - conda update --yes --all 'python<=2.7.12'
-
 install:
     - pip install --upgrade 'git+https://github.com/cdeepakroy/ctk-cli'
     - cd $girder_path
@@ -67,11 +69,18 @@ install:
     - girder-install web --plugins=slicer_cli_web,worker,jobs --dev
 
 script:
+    - cd $girder_worker_path
+    - python2 -m girder_worker -l info >/tmp/worker.out 2>&1 &
     - mkdir -p $build_path/girder_testing_build
     - cd $build_path/girder_testing_build
     - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DPYTHON_COVERAGE_CONFIG="$main_path/plugin_tests/pycoverage.cfg" -DCOVERAGE_MINIMUM_PASS=19 -DJS_COVERAGE_MINIMUM_PASS=19 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="slicer_cli_web" $girder_path
     - make
     - JASMINE_TIMEOUT=15000 ctest -VV
 
+after_failure:
+  # On failures, show the worker output and other information
+  - pip freeze
+  - cat /tmp/worker.out
+
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash) -R $main_path -s $girder_path

--- a/plugin_tests/data/girder_worker.cfg
+++ b/plugin_tests/data/girder_worker.cfg
@@ -1,6 +1,6 @@
 [celery]
 app_main=girder_worker
-broker=mongodb://127.0.0.1/girder_worker
+broker=amqp://guest@127.0.0.1/
 
 [girder_worker]
 # Root dir where temp files for jobs will be written

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker>=2
+docker>=2,<3
 six>=1.10.0
 jsonschema>=2.5.1


### PR DESCRIPTION
Pin docker python module to version 2.x, as version 3 has breaking changes.

Use girder_worker with the rabbitmq broker and start it explicitly.