### PR TITLE
Add a new event `h:analysis:rendered`

### DIFF
--- a/web_client/views/PanelGroup.js
+++ b/web_client/views/PanelGroup.js
@@ -58,6 +58,7 @@ var PanelGroup = View.extend({
             this._panelViews[panel.id].render();
         }, this));
 
+        events.trigger('h:analysis:rendered', this);
         return this;
     },
 


### PR DESCRIPTION
Sometimes (and I'm at a loss for why) the rendering of the panels occur
asynchronously.  The use case for this event in HistomicsTK requires
that default values be inserted *after* the rendering occurs.  This adds
a new event that HistomicsTK can listen to that is guaranteed to occur
after the render.