### PR TITLE
Support optional file outputs.

### DIFF
--- a/plugin_tests/parseSpec.js
+++ b/plugin_tests/parseSpec.js
@@ -285,6 +285,29 @@ describe('XML Schema parser', function () {
                 title: 'arg1',
                 description: 'A description',
                 channel: 'output',
+                required: false,
+                extensions: '.txt'
+            });
+
+            xml = $.parseXML(
+                '<file fileExtensions=".txt">' +
+                    '<name>foo</name>' +
+                    '<index>0</index>' +
+                    '<channel>output</channel>' +
+                    '<label>arg1</label>' +
+                    '<description>A description</description>' +
+                    '</file>'
+            );
+            expect(parser.param(
+                $(xml).find('file').get(0)
+            )).toEqual({
+                type: 'new-file',
+                slicerType: 'file',
+                id: 'foo',
+                title: 'arg1',
+                description: 'A description',
+                channel: 'output',
+                required: true,
                 extensions: '.txt'
             });
         });

--- a/server/docker_resource.py
+++ b/server/docker_resource.py
@@ -127,9 +127,7 @@ class DockerResource(Resource):
     def deleteImage(self, params):
         self.requireParams(('name',), params)
         if 'delete_from_local_repo' in params:
-            deleteImage = params['delete_from_local_repo']
-            if deleteImage is 'True':
-                deleteImage = True
+            deleteImage = str(params['delete_from_local_repo']).lower() == 'true'
         else:
             deleteImage = False
         nameList = self.parseImageNameList(params['name'])

--- a/web_client/collections/WidgetCollection.js
+++ b/web_client/collections/WidgetCollection.js
@@ -22,8 +22,10 @@ var WidgetCollection = Backbone.Collection.extend({
                     params[m.id + '_girderItemId'] = m.value().id;
                     break;
                 case 'new-file':
-                    params[m.id + '_girderFolderId'] = m.value().get('folderId');
-                    params[m.id + '_name'] = m.value().get('name');
+                    if (m && m.value && m.value()) {
+                        params[m.id + '_girderFolderId'] = m.value().get('folderId');
+                        params[m.id + '_name'] = m.value().get('name');
+                    }
                     break;
                 case 'image':
                     params[m.id + '_girderFileId'] = m.value().id;

--- a/web_client/models/WidgetModel.js
+++ b/web_client/models/WidgetModel.js
@@ -227,7 +227,10 @@ var WidgetModel = Backbone.Model.extend({
      */
     _validateGirderModel: function (model) {
         var parent;
-        if (!model.value) {
+        if (!model.value || !model.value.get('name')) {
+            if (this.get('type') === 'new-file' && !this.get('required')) {
+                return;
+            }
             return 'Empty value';
         }
 

--- a/web_client/parser/param.js
+++ b/web_client/parser/param.js
@@ -27,6 +27,7 @@ function param(paramTag, opts = {}) {
     if ((type === 'file' || type === 'image') && channel === 'output') {
         type = 'new-file';
         extra['extensions'] = $param.attr('fileExtensions');
+        extra['required'] = $param.find('index').text().length > 0;
     } else if (channel === 'output') {
         opts.output = true;
         opts.params = _.extend(opts.params || {}, {

--- a/web_client/views/JobsListWidget.js
+++ b/web_client/views/JobsListWidget.js
@@ -82,7 +82,7 @@ const JobsListWidget = View.extend({
 
             // check if the file still exists
             restRequest({
-                path: `file/${id}`,
+                url: `file/${id}`,
                 error: null
             }).done((file) => {
                 paramFiles[job.id] = file;
@@ -94,7 +94,7 @@ const JobsListWidget = View.extend({
     _clickParamFile(evt) {
         const fileId = $(evt.currentTarget).data('file-id');
         restRequest({
-            path: `file/${fileId}/download`,
+            url: `file/${fileId}/download`,
             dataType: 'text'
         }).done((parameters) => {
             const view = new OutputParameterDialog({


### PR DESCRIPTION
Prior to this, optional file outputs were ignored.  This marks a file output with required = (boolean) based on whether is is optional (doesn't have an index).

If it is optional, an empty value will validate within the javascript.

This also fixes a Girder warning about using path vs url in restRequest.