### PR TITLE
Test on Python 3.5 and 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
     - "2.7"
+    - "3.5"
+    - "3.6"
 
 cache:
     directories:

--- a/plugin_tests/docker_test.py
+++ b/plugin_tests/docker_test.py
@@ -298,7 +298,7 @@ class DockerImageManagementTest(base.TestCase):
                 self.fail('A status ok or code 200 should not have been '
                           'recieved for deleting the image %s' % str(name))
             except Exception:
-                    pass
+                pass
         if deleteDockerImage:
             if not event.wait(TIMEOUT):
                 del self.delHandler
@@ -353,8 +353,7 @@ class DockerImageManagementTest(base.TestCase):
 
         if not event.wait(TIMEOUT):
             del self.addHandler
-            self.fail('adding the docker image is taking '
-                      'longer than %d seconds' % TIMEOUT)
+            self.fail('adding the docker image is taking longer than %d seconds' % TIMEOUT)
         else:
             del self.addHandler
             self.assertEqual(job_status[0], status,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-docker>=2,<3
+docker>=2
 six>=1.10.0
 jsonschema>=2.5.1

--- a/server/cli_list_entrypoint.py
+++ b/server/cli_list_entrypoint.py
@@ -57,7 +57,7 @@ def CLIListEntrypoint(cli_list_spec_file=None):
         cli_list_spec_file = os.path.join(os.getcwd(), 'slicer_cli_list.json')
 
     # Parse CLI List spec
-    with open(cli_list_spec_file) as f:
+    with open(cli_list_spec_file, 'rt') as f:
         cli_list_spec = json.load(f)
 
     # create command-line argument parser

--- a/server/docker_resource.py
+++ b/server/docker_resource.py
@@ -30,7 +30,7 @@ from girder.api import access
 from girder.api.describe import Description, describeRoute
 from .rest_slicer_cli import genRESTEndPointsForSlicerCLIsInDockerCache
 from girder.plugins.jobs.constants import JobStatus
-from models import DockerImageNotFoundError, DockerImage
+from .models import DockerImageNotFoundError, DockerImage
 
 
 class DockerResource(Resource):
@@ -59,14 +59,12 @@ class DockerResource(Resource):
 
         dockermodel = ModelImporter.model('docker_image_model',
                                           'slicer_cli_web')
-
         dockerCache = dockermodel.loadAllImages()
         cache = dockerCache.getImages()
         data = {}
         for val in cache:
             name, tag, imgData = self.createRestDataForImageVersion(val)
             data.setdefault(name, {})[tag] = imgData
-
         return data
 
     def createRestDataForImageVersion(self, dockerImage):
@@ -166,6 +164,8 @@ class DockerResource(Resource):
         :returns: a list of image names.
         """
         nameList = param
+        if isinstance(param, six.binary_type):
+            param = param.decode('utf8')
         if isinstance(param, six.string_types):
             try:
                 nameList = json.loads(param)
@@ -243,7 +243,7 @@ class DockerResource(Resource):
 
         if imageList is None:
             imageList = self.currentEndpoints.keys()
-        for imageName in imageList:
+        for imageName in list(imageList):
             if imageName in self.currentEndpoints:
                 for (cli, val) in six.iteritems(
                         self.currentEndpoints[imageName]):
@@ -261,7 +261,7 @@ class DockerResource(Resource):
         Determines if the job event being triggered is due to the caching of
         new docker images or deleting a docker image off the local machine.  If
         a new image is being loaded all old rest endpoints are deleted and
-        endpoints fro all cached docker images are regenerated.
+        endpoints for all cached docker images are regenerated.
 
         :param event: An event dictionary
         """

--- a/server/models/docker_image.py
+++ b/server/models/docker_image.py
@@ -18,9 +18,9 @@
 ###############################################################################
 
 
-from six import iteritems, string_types
 import hashlib
 import jsonschema
+import six
 
 from girder import logger
 
@@ -36,7 +36,7 @@ class DockerImageError(Exception):
     def __str__(self):
         if isinstance(self.imageName, list):
             return self.message + ' (image names [' + ','.join(self.imageName) + '])'
-        elif isinstance(self.imageName, string_types):
+        elif isinstance(self.imageName, six.string_types):
             return self.message + ' (image name: ' + self.imageName + ' )'
         else:
             return self.message
@@ -61,21 +61,19 @@ class DockerImage(object):
     cli_dict = 'cli_list'
     # structure of the dictionary to store metadata
     # {
-    # imagehash:<hash of docker image name>
-    #     cli_list: {
-    #         cli_name: {
-    #                   type: < type >
-    #                   xml: < xml >
-    #
-    # }
-    # }
-    # docker_image_name: < name >
+    #     'imagehash': <hash of docker image name>
+    #     'cli_list': {
+    #         <cli_name>: {
+    #             'type': <type>
+    #             'xml': <xml>
+    #         }
+    #     }
+    #     'docker_image_name': <name>
     # }
 
     def __init__(self, name):
         try:
-            if isinstance(name, string_types):
-
+            if isinstance(name, six.string_types):
                 imageKey = DockerImage.getHashKey(name)
                 self.data = {}
                 self.data[DockerImage.imageName] = name
@@ -90,10 +88,9 @@ class DockerImage(object):
                 self.name = self.data[DockerImage.imageName]
                 self.hash = DockerImage.getHashKey(self.name)
             else:
-
-                raise DockerImageError('Image should be a string, or dict'
-                                       ' could not add the image',
-                                       'bad init val')
+                raise DockerImageError(
+                    'Image should be a string, or dict could not add the image',
+                    'bad init val')
         except Exception as err:
             logger.exception('Could not initialize docker image %r', name)
             raise DockerImageError(
@@ -151,7 +148,7 @@ class DockerImage(object):
         }
         """
         spec_dict = {}
-        for (key, val) in iteritems(self.data[DockerImage.cli_dict]):
+        for (key, val) in six.iteritems(self.data[DockerImage.cli_dict]):
             spec_dict[key] = val[DockerImage.type]
         return spec_dict
 
@@ -229,7 +226,7 @@ class DockerCache(object):
 
     def getRawData(self):
         dataCopy = {}
-        for (key, val) in iteritems(self.data):
+        for (key, val) in six.iteritems(self.data):
             dataCopy[key] = val.getRawData()
         return dataCopy
 
@@ -244,7 +241,7 @@ class DockerCache(object):
     def getAllCliSpec(self):
         spec_dict = {}
 
-        for (key, val) in iteritems(self.data):
+        for (key, val) in six.iteritems(self.data):
             spec_dict[val.name] = val.getCLIListSpec()
 
         return spec_dict

--- a/small-docker/cli_list.py
+++ b/small-docker/cli_list.py
@@ -7,7 +7,7 @@ import subprocess
 def processCLI(filename):
     try:
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                               filename), 'rb') as f:
+                               filename), 'rt') as f:
             list_spec = json.load(f)
     except Exception:
         print('Failed to parse %s' % filename)


### PR DESCRIPTION
Various fixes to work with Python 3.

Curiously, Python 3.6 will parse json as either bytes or str, but 3.5 requires it to be str (and Python 2.7 can be str or unicode).