### PR TITLE
Restructure CI scirpt to upload coverage and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ executors:
     docker:
       - image: girder/girder_test:latest-py3
       - image: circleci/mongo:3.4-ram
-        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
-        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
       - image: rabbitmq
 
@@ -99,7 +97,6 @@ jobs:
       - tox:
           env: flake8,lintclient
   py27:
-    working_directory: ~/project
     executor: py2
     steps:
       - checkout
@@ -107,7 +104,6 @@ jobs:
       - tox:
           env: py27
   py36:
-    working_directory: ~/project
     executor: py3
     steps:
       - checkout
@@ -115,7 +111,6 @@ jobs:
       - tox:
           env: py36
   py37:
-    working_directory: ~/project
     executor: py3
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,23 @@
 version: 2.1
+
 orbs:
   codecov: codecov/codecov@1.0.5
-jobs:
-  lint:
-    working_directory: ~/project
-    docker:
-      - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.4-ram
-        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
-        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
+commands:
+  tox:
+    description: "run tox"
+    parameters:
+      env:
+        type: string
     steps:
-      - checkout
       - run:
           name: Run tests via tox
           # Piping through cat does less buffering of the output but can
           # consume the exit code
-          command: tox -e flake8,lintclient  | cat; test ${PIPESTATUS[0]} -eq 0
-      # - run:
-      #     name: Install Codecov client
-      #     command: pip install codecov
-      # - run:
-      #     name: Upload coverage
-      #     # Retry as codecov can be flaky
-      #     command: for i in $(seq 1 10); do [ %i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --required --disable search pycov gcov --root project --file build/test/coverage/py_coverage.xml build/test/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
-  py27:
+          command: tox -e << parameters.env >>  | cat; test ${PIPESTATUS[0]} -eq 0
+
+executors:
+  py2:
     working_directory: ~/project
     docker:
       - image: girder/girder_test:latest-py2
@@ -34,51 +26,65 @@ jobs:
         # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
       - image: rabbitmq
+  py3:
+    working_directory: ~/project
+    docker:
+      - image: girder/girder_test:latest-py3
+      - image: circleci/mongo:3.4-ram
+        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
+        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
+        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
+      - image: rabbitmq
+
+jobs:
+  lint:
+    executor: py3
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Run tests via tox
-          command: tox -e py27 | cat; test ${PIPESTATUS[0]} -eq 0
+      - tox:
+          env: flake8,lintclient
+  py27:
+    working_directory: ~/project
+    executor: py2
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py27
   py36:
     working_directory: ~/project
-    docker:
-      - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.4-ram
-        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
-        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
-      - image: rabbitmq
+    executor: py3
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Run tests via tox
-          command: tox -e py36 | cat; test ${PIPESTATUS[0]} -eq 0
+      - setup_remote_docker
+      - tox:
+          env: py36
   py37:
     working_directory: ~/project
-    docker:
-      - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.4-ram
-        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
-        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
-      - image: rabbitmq
+    executor: py3
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - run:
-          name: Run tests via tox
-          command: tox -e py37 | cat; test ${PIPESTATUS[0]} -eq 0
+      - setup_remote_docker
+      - tox:
+          env: py37
       - codecov/upload:
           file: .tox/coverage/py_coverage.xml
           flags: backend
       - codecov/upload:
           file: build/test/coverage/web_temp/*.json
           flags: ui
+      - store_test_results:
+          path: build/test-reports
+      - store_artifacts:
+          path: build/test-reports
+  deploy:
+    executor: py3
+    steps:
+      - checkout
+      - setup_remote_docker
+      - deploy:
+          command: tox -e release
+
 workflows:
   version: 2
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.5
 jobs:
   lint:
     working_directory: ~/project
@@ -71,6 +73,12 @@ jobs:
       - run:
           name: Run tests via tox
           command: tox -e py37 | cat; test ${PIPESTATUS[0]} -eq 0
+      - codecov/upload:
+          file: .tox/coverage/py_coverage.xml
+          flags: backend
+      - codecov/upload:
+          file: build/test/coverage/web_temp/*.json
+          flags: ui
 workflows:
   version: 2
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,3 +105,14 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - deploy:
+          requires:
+            - lint
+            - py27
+            - py36
+            - py37
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,64 @@
 version: 2.1
 
-orbs:
-  codecov: codecov/codecov@1.0.5
-
 commands:
+  upload:
+    parameters:
+      conf:
+        description: Used to specify the location of the .codecov.yml config file
+        type: string
+        default: ".codecov.yml"
+      file:
+        description: Path to the code coverage data file to upload.
+        type: string
+        default: ""
+      flags:
+        description: Flag the upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
+        type: string
+        default: ""
+      token:
+        description: Set the private repository token (defaults to environment variable $CODECOV_TOKEN)
+        type: string
+        default: ${CODECOV_TOKEN}
+      upload_name:
+        description: Custom defined name of the upload. Visible in Codecov UI
+        type: string
+        default: ${CIRCLE_BUILD_NUM}
+      url:
+        description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
+        type: string
+        default: "https://codecov.io/bash"
+      when:
+        description: When should this step run?
+        type: string
+        default: "always"
+    steps:
+      - when:
+          condition: << parameters.file >>
+          steps:
+            - run:
+                name: Upload Coverage Results
+                command: |
+                  curl -s << parameters.url >> | bash -s -- \
+                    -f "<< parameters.file >>" \
+                    -t "<< parameters.token >>" \
+                    -n "<< parameters.upload_name >>" \
+                    -y "<< parameters.conf >>" \
+                    -F "<< parameters.flags >>" \
+                    -Z || echo 'Codecov upload failed'
+                when: << parameters.when >>
+      - unless:
+          condition: << parameters.file >>
+          steps:
+            - run:
+                name: Upload Coverage Results
+                command: |
+                  curl -s << parameters.url >> | bash -s -- \
+                    -t "<< parameters.token >>" \
+                    -n "<< parameters.upload_name >>" \
+                    -y "<< parameters.conf >>" \
+                    -F "<< parameters.flags >>" \
+                    -Z || echo 'Codecov upload failed'
+                when: << parameters.when >>
   tox:
     description: "run tox"
     parameters:
@@ -67,10 +122,10 @@ jobs:
       - setup_remote_docker
       - tox:
           env: py37
-      - codecov/upload:
+      - upload:
           file: .tox/coverage/py_coverage.xml
           flags: backend
-      - codecov/upload:
+      - upload:
           file: build/test/coverage/web_temp/*.json
           flags: ui
       - store_test_results:

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ slicer_cli_web |build-status| |codecov-io|
 
 A girder plugin for exposing slicer execution model CLIs over the web using docker and girder_worker
 
-.. |build-status| image:: https://travis-ci.org/girder/slicer_cli_web.svg?branch=master
-    :target: https://travis-ci.org/girder/slicer_cli_web
+.. |build-status| image:: https://circleci.com/gh/girder/slicer_cli_web.svg?style=svg
+    :target: https://circleci.com/gh/girder/slicer_cli_web
     :alt: Build Status
 
 .. |codecov-io| image:: https://codecov.io/github/girder/slicer_cli_web/coverage.svg?branch=master

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {}
 
 # perform the install
 setup(
-    name='slicer-cli-web',
+    name='girder-slicer-cli-web',
     use_scm_version={'local_scheme': prerelease_local_scheme},
     setup_requires=['setuptools-scm'],
     description='A girder plugin for exposing slicer CLIs over the web',

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,9 @@ commands =
   rm -rf build/test/coverage/web_temp
   girder build --dev
   pytest --cov {envsitepackagesdir}/slicer_cli_web {posargs}
-  npx nyc report --temp-dir .tox/coverage --report-dir .tox/coverage --reporter cobertura --reporter text-summary
-# When client tests are enabled, add the temp-dir.
-# npx nyc report --temp-dir build/test/coverage/web_temp --report-dir .tox/coverage --reporter cobertura --reporter text-summary
+  # npx nyc report --temp-dir .tox/coverage --report-dir .tox/coverage --reporter cobertura --reporter text-summary
+  # When client tests are enabled, add the temp-dir.
+  npx nyc report --temp-dir build/test/coverage/web_temp --report-dir .tox/coverage --reporter cobertura --reporter text-summary
 
 [testenv:flake8]
 skipsdist = true

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,10 @@ whitelist_externals =
   npx
 commands =
   rm -rf build/test/coverage/web_temp
+  mkdir -p build/test-reports
+  rm -rf build/test-reports
   girder build --dev
-  pytest --cov {envsitepackagesdir}/slicer_cli_web {posargs}
+  pytest --cov {envsitepackagesdir}/slicer_cli_web --junitxml=build/test-reports/junit.xml {posargs}
   # npx nyc report --temp-dir .tox/coverage --report-dir .tox/coverage --reporter cobertura --reporter text-summary
   # When client tests are enabled, add the temp-dir.
   npx nyc report --temp-dir build/test/coverage/web_temp --report-dir .tox/coverage --reporter cobertura --reporter text-summary


### PR DESCRIPTION
closes #71, closes #73 

doesn't work so far, since

```
#!/bin/sh -eo pipefail
# Orb codecov/codecov@1.0.5 not loaded. To use this orb, an organization admin must opt-in to using third party orbs in Organization Security settings.
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
Exited with code 1
CircleCI received exit code 1
```

Moreover, the proper environment variable with the Token needs to be set

@manthey can you take a look at it?