### PR TITLE
Task independence

### DIFF
--- a/slicer_cli_web/docker_resource.py
+++ b/slicer_cli_web/docker_resource.py
@@ -61,7 +61,8 @@ class DockerResource(Resource):
         self.route('GET', (name, 'cli', ':id', 'xml'), self.getItemXML)
 
         # sort by name and creation date desc
-        items = sorted(CLIItem.findAllItems(), key=lambda x: (x.restPath, x.item['created']), reverse=True)
+        items = sorted(CLIItem.findAllItems(), key=lambda x: (x.restPath, x.item['created']),
+                       reverse=True)
 
         seen = set()
         for item in items:

--- a/slicer_cli_web/docker_resource.py
+++ b/slicer_cli_web/docker_resource.py
@@ -50,15 +50,15 @@ class DockerResource(Resource):
         self.currentEndpoints = {}
         self.resourceName = name
         self.jobType = 'slicer_cli_web_job'
-        self.route('PUT', (name, 'docker_image'), self.setImages)
-        self.route('DELETE', (name, 'docker_image'), self.deleteImage)
-        self.route('GET', (name, 'docker_image'), self.getDockerImages)
+        self.route('PUT', ('docker_image',), self.setImages)
+        self.route('DELETE', ('docker_image',), self.deleteImage)
+        self.route('GET', ('docker_image',), self.getDockerImages)
 
-        self.route('GET', (name, 'cli'), self.getItems)
-        self.route('GET', (name, 'cli', ':id',), self.getItem)
-        self.route('DELETE', (name, 'cli', ':id',), self.deleteItem)
+        self.route('GET', ('cli',), self.getItems)
+        self.route('GET', ('cli', ':id',), self.getItem)
+        self.route('DELETE', ('cli', ':id',), self.deleteItem)
         # run is generated per item for better validation
-        self.route('GET', (name, 'cli', ':id', 'xml'), self.getItemXML)
+        self.route('GET', ('cli', ':id', 'xml'), self.getItemXML)
 
         self._generateAllItemEndPoints()
 
@@ -72,7 +72,7 @@ class DockerResource(Resource):
         for image in DockerImageItem.findAllImages(self.getCurrentUser()):
             imgData = {}
             for cli in image.getCLIs():
-                basePath = '/%s/slicer_cli_web/cli/%s' % (self.resourceName, cli._id)
+                basePath = '/%s/cli/%s' % (self.resourceName, cli._id)
                 imgData[cli.name] = {
                     'type': cli.type,
                     'xmlspec': basePath + '/xml',

--- a/slicer_cli_web/docker_resource.py
+++ b/slicer_cli_web/docker_resource.py
@@ -80,10 +80,10 @@ class DockerResource(Resource):
         for image in DockerImageItem.findAllImages(self.getCurrentUser()):
             imgData = {}
             for cli in image.getCLIs():
-                basePath = '/%s/cli/%s' % (self.resourceName, cli._id)
+                basePath = '/%s/slicer_cli_web/cli/%s' % (self.resourceName, cli._id)
                 imgData[cli.name] = {
                     'type': cli.type,
-                    'xml': basePath + '/xml',
+                    'xmlspec': basePath + '/xml',
                     'run': basePath + '/run'
                 }
             data.setdefault(image.image, {})[image.tag] = imgData
@@ -278,6 +278,7 @@ class DockerResource(Resource):
             '_id': item._id,
             'name': item.name,
             'type': item.type,
+            'image': item.image,
             'description': item.item['description']
         }
         if details:

--- a/slicer_cli_web/girder_plugin.py
+++ b/slicer_cli_web/girder_plugin.py
@@ -23,9 +23,8 @@ from girder.utility.model_importer import ModelImporter
 from girder.plugin import getPlugin, GirderPlugin
 from girder.constants import AccessType
 
-from .rest_slicer_cli import genRESTEndPointsForSlicerCLIsForItem
 from .docker_resource import DockerResource
-from .models import DockerImageItem, CLIItem
+from .models import DockerImageItem
 
 
 def _onUpload(event):
@@ -59,9 +58,6 @@ class SlicerCLIWebPlugin(GirderPlugin):
         # passed in resource name must match the attribute added to info[apiroot]
         resource = DockerResource('slicer_cli_web')
         info['apiRoot'].slicer_cli_web = resource
-
-        for item in CLIItem.findAllItems():
-            genRESTEndPointsForSlicerCLIsForItem(resource, item)
 
         ModelImporter.model('job', 'jobs').exposeFields(level=AccessType.READ, fields={
             'slicerCLIBindings'})

--- a/slicer_cli_web/girder_plugin.py
+++ b/slicer_cli_web/girder_plugin.py
@@ -23,9 +23,9 @@ from girder.utility.model_importer import ModelImporter
 from girder.plugin import getPlugin, GirderPlugin
 from girder.constants import AccessType
 
-from .rest_slicer_cli import genRESTEndPointsForSlicerCLIsForImage
+from .rest_slicer_cli import genRESTEndPointsForSlicerCLIsForItem
 from .docker_resource import DockerResource
-from .models import DockerImageItem
+from .models import DockerImageItem, CLIItem
 
 
 def _onUpload(event):
@@ -60,8 +60,8 @@ class SlicerCLIWebPlugin(GirderPlugin):
         resource = DockerResource('slicer_cli_web')
         info['apiRoot'].slicer_cli_web = resource
 
-        for image in DockerImageItem.findAllImages():
-            genRESTEndPointsForSlicerCLIsForImage(resource, image)
+        for item in CLIItem.findAllItems():
+            genRESTEndPointsForSlicerCLIsForItem(resource, item)
 
         ModelImporter.model('job', 'jobs').exposeFields(level=AccessType.READ, fields={
             'slicerCLIBindings'})

--- a/slicer_cli_web/models/docker_image.py
+++ b/slicer_cli_web/models/docker_image.py
@@ -43,14 +43,14 @@ class CLIItem(object):
         self.name = item['name']
         meta = item['meta']
         self.type = meta['type']
-        self.image = meta.get('image', None)
+        self.image = meta.get('image', 'UNKNOWN')
         self.digest = meta.get('digest', self.image)
         self.xml = meta['xml']
         if isinstance(self.xml, six.text_type):
             self.xml = self.xml.encode('utf8')
 
-        base = self.image.replace(':', '_').replace('/', '_').replace('@', '_')
-        self.restPath = '%s/%s' % (base, self.name)
+        self.restBasePath = self.image.replace(':', '_').replace('/', '_').replace('@', '_')
+        self.restPath = '%s/%s' % (self.restBasePath, self.name)
 
     @staticmethod
     def find(itemId, user):

--- a/slicer_cli_web/models/docker_image.py
+++ b/slicer_cli_web/models/docker_image.py
@@ -109,7 +109,6 @@ class CLIItem(object):
         ])
 
         leaves = next(r)['leaves']
-        print(leaves)
 
         return CLIItem._findAllItemImpl(user, {
             'folderId': {'$in': [baseFolder['_id']] + leaves}
@@ -257,7 +256,8 @@ class DockerImageItem(object):
         existingItems = {item['name']: item for item in children}
 
         for cli, desc in six.iteritems(cli_dict):
-            item = itemModel.createItem(cli, user, image.tagFolder, 'Slicer CLI generated CLI command item',
+            item = itemModel.createItem(cli, user, image.tagFolder,
+                                        'Slicer CLI generated CLI command item',
                                         reuseExisting=True)
             meta_data = dict(slicerCLIType='task', type=desc.get('type', 'Unknown'))
 

--- a/slicer_cli_web/models/docker_image.py
+++ b/slicer_cli_web/models/docker_image.py
@@ -55,6 +55,21 @@ class CLIItem(object):
             return None
         return CLIItem(item)
 
+    @staticmethod
+    def findAllItems(user=None, baseFolder=None):
+        itemModel = Item()
+        q = {'meta.slicerCLIType': 'task'}
+        # TODO find all recursively
+        if baseFolder:
+            q['parentId'] = baseFolder['_id']
+
+        if user:
+            items = itemModel.findWithPermissions(q, user=user, level=AccessType.READ)
+        else:
+            items = itemModel.find(q)
+
+        return [CLIItem(item) for item in items]
+
 
 class DockerImageItem(object):
     def __init__(self, imageFolder, tagFolder, user):

--- a/slicer_cli_web/models/docker_image.py
+++ b/slicer_cli_web/models/docker_image.py
@@ -41,11 +41,16 @@ class CLIItem(object):
         self.item = item
         self._id = item['_id']
         self.name = item['name']
-        desc = item['meta']
-        self.type = desc['type']
-        self.xml = desc['xml']
+        meta = item['meta']
+        self.type = meta['type']
+        self.image = meta.get('image', None)
+        self.digest = meta.get('digest', self.image)
+        self.xml = meta['xml']
         if isinstance(self.xml, six.text_type):
             self.xml = self.xml.encode('utf8')
+
+        base = self.image.replace(':', '_').replace('/', '_').replace('@', '_')
+        self.restPath = '%s/%s' % (base, self.name)
 
     @staticmethod
     def find(itemId, user):
@@ -56,12 +61,12 @@ class CLIItem(object):
         return CLIItem(item)
 
     @staticmethod
-    def findAllItems(user=None, baseFolder=None):
+    def _findAllItemImpl(user=None, extraQuery=None):
         itemModel = Item()
         q = {'meta.slicerCLIType': 'task'}
-        # TODO find all recursively
-        if baseFolder:
-            q['parentId'] = baseFolder['_id']
+
+        if extraQuery:
+            q.update(extraQuery)
 
         if user:
             items = itemModel.findWithPermissions(q, user=user, level=AccessType.READ)
@@ -69,6 +74,46 @@ class CLIItem(object):
             items = itemModel.find(q)
 
         return [CLIItem(item) for item in items]
+
+    @staticmethod
+    def findAllItems(user=None, baseFolder=None):
+        if not baseFolder:
+            return CLIItem._findAllItemImpl(user)
+
+        folderModel = Folder()
+        graphLookup = {
+            'from': 'folder',
+            'startWith': '$_id',
+            'connectFromField': '_id',
+            'connectToField': 'parentId',
+            'as': 'children'
+        }
+
+        if user and not user['admin']:
+            graphLookup['restrictSearchWithMatch'] = folderModel.permissionClauses(user,
+                                                                                   AccessType.READ)
+
+        # see https://docs.mongodb.com/manual/reference/operator/aggregation/graphLookup
+        r = folderModel.collection.aggregate([
+            {
+                '$match': dict(_id=baseFolder['_id'])
+            },
+            {
+                '$graphLookup': graphLookup
+            },
+            {
+                '$project': {
+                    'leaves': '$children._id',
+                }
+            }
+        ])
+
+        leaves = next(r)['leaves']
+        print(leaves)
+
+        return CLIItem._findAllItemImpl(user, {
+            'folderId': {'$in': [baseFolder['_id']] + leaves}
+        })
 
 
 class DockerImageItem(object):
@@ -80,9 +125,8 @@ class DockerImageItem(object):
         self.tagFolder = tagFolder
         self._id = self.tagFolder['_id']
         self.user = user
+        self.name = '%s:%s' % (self.image, self.tag)
         self.digest = tagFolder['meta'].get('digest', self.name)
-
-        self.restPath = self.name.replace(':', '_').replace('/', '_').replace('@', '_')
 
     def getCLIs(self):
         itemModel = Item()
@@ -165,17 +209,11 @@ class DockerImageItem(object):
         return removed
 
     @staticmethod
-    def saveImage(name, cli_dict, docker_image, user, baseFolder):
-        """
-        :param baseFolder
-        :type Folder
-        """
+    def _create(name, docker_image, user, baseFolder):
         folderModel = Folder()
-        itemModel = Item()
         fileModel = File()
 
         imageName, tagName = _split(name)
-        restPath = name.replace(':', '_').replace('/', '_').replace('@', '_')
 
         image = folderModel.createFolder(baseFolder, imageName,
                                          'Slicer CLI generated docker image folder',
@@ -198,22 +236,35 @@ class DockerImageItem(object):
         labels = {k.replace('.', '_'): v for k, v in six.iteritems(labels)}
         if 'Author' in docker_image.attrs:
             labels['author'] = docker_image.attrs['Author']
+
+        digest = None
         if docker_image.attrs.get('RepoDigests', []):
-            labels['digest'] = docker_image.attrs['RepoDigests'][0]
-        else:
-            labels['digest'] = None
+            digest = docker_image.attrs['RepoDigests'][0]
+
+        labels['digest'] = digest
         folderModel.setMetadata(tag, labels)
 
-        folderModel.setMetadata(tag, dict(slicerCLIType='tag', slicerCLIRestPath=restPath))
-        children = folderModel.childItems(tag, filters={'meta.slicerCLIType': 'task'})
+        folderModel.setMetadata(tag, dict(slicerCLIType='tag'))
+
+        return DockerImageItem(image, tag, user)
+
+    @staticmethod
+    def _syncItems(image, cli_dict, user):
+        folderModel = Folder()
+        itemModel = Item()
+
+        children = folderModel.childItems(image.tagFolder, filters={'meta.slicerCLIType': 'task'})
         existingItems = {item['name']: item for item in children}
 
         for cli, desc in six.iteritems(cli_dict):
-            item = itemModel.createItem(cli, user, tag, 'Slicer CLI generated CLI command item',
+            item = itemModel.createItem(cli, user, image.tagFolder, 'Slicer CLI generated CLI command item',
                                         reuseExisting=True)
-            meta_data = dict(slicerCLIType='task')
-            if 'type' in desc:
-                meta_data['type'] = desc['type']
+            meta_data = dict(slicerCLIType='task', type=desc.get('type', 'Unknown'))
+
+            # copy some things from the image to be independent
+            meta_data['image'] = image.name
+            meta_data['digest'] = image.digest if image.name != image.digest else None
+
             desc_type = desc.get('desc-type', 'xml')
 
             if desc_type == 'xml':
@@ -232,7 +283,17 @@ class DockerImageItem(object):
         for item in six.itervalues(existingItems):
             itemModel.remove(item)
 
-        return DockerImageItem(image, tag, user)
+    @staticmethod
+    def saveImage(name, cli_dict, docker_image, user, baseFolder):
+        """
+        :param baseFolder
+        :type Folder
+        """
+
+        image = DockerImageItem._create(name, docker_image, user, baseFolder)
+        DockerImageItem._syncItems(image, cli_dict, user)
+
+        return image
 
     @staticmethod
     def prepare():

--- a/slicer_cli_web/rest_slicer_cli.py
+++ b/slicer_cli_web/rest_slicer_cli.py
@@ -242,7 +242,7 @@ def genRESTEndPointsForSlicerCLIsForItem(restResource, cliItem, registerNamedRou
         cliRunHandlerName = 'run_%s' % cliItem._id
         setattr(restResource, cliRunHandlerName, cliRunHandler)
 
-        restRunPath = ('slicer_cli_web', 'cli', str(cliItem._id), 'run')
+        restRunPath = ('cli', str(cliItem._id), 'run')
         restResource.route('POST', restRunPath, cliRunHandler)
 
         if registerNamedRoute:

--- a/slicer_cli_web/rest_slicer_cli.py
+++ b/slicer_cli_web/rest_slicer_cli.py
@@ -210,46 +210,6 @@ def genHandlerToRunDockerCLI(dockerImage, dockerImageDigest, cliItem, restResour
     return cliHandler
 
 
-def genHandlerToGetDockerCLIXmlSpec(itemId, name, restResource):
-    """Generates a handler that returns the XML spec of the docker CLI
-
-    Parameters
-    ----------
-    itemId : str
-        Girder Item Id
-    name : str
-        Relative path of the CLI which is needed to run the CLI by running
-        the command docker run `dockerImage` `name`
-    cliXML: str
-        value of clispec stored in settings
-    restResource : girder.api.rest.Resource
-        The object of a class derived from girder.api.rest.Resource to which
-        this handler will be attached
-
-    Returns
-    -------
-    function
-        Returns a function that returns the xml spec of the CLI
-
-    """
-
-    # define the handler that returns the CLI's xml spec
-    @boundHandler(restResource)
-    @access.user
-    @describeRoute(
-        Description('Get XML spec of %s CLI' % name).produces('application/xml')
-    )
-    def getXMLSpecHandler(self, *args, **kwargs):
-        item = CLIItem.find(itemId, self.getCurrentUser())
-        if not item:
-            raise RestException('Invalid CLI Item id (%s).' % (itemId))
-        setResponseHeader('Content-Type', 'application/xml')
-        setRawResponse()
-        return item.xml
-
-    return getXMLSpecHandler
-
-
 def genRESTEndPointsForSlicerCLIsForImage(restResource, docker_image):
     """Generates REST end points for slicer CLIs placed in subdirectories of a
     given root directory and attaches them to a REST resource with the given

--- a/slicer_cli_web/web_client/views/CollectionView.js
+++ b/slicer_cli_web/web_client/views/CollectionView.js
@@ -58,7 +58,7 @@ const UploadImageDialog = View.extend({
         const name = data.get('name').split(',').map((d) => d.trim()).filter((d) => d.length > 0);
         return restRequest({
             type: 'PUT',
-            url: 'slicer_cli_web/slicer_cli_web/docker_image',
+            url: 'slicer_cli_web/docker_image',
             data: {
                 name: JSON.stringify(name)
             },

--- a/slicer_cli_web/web_client/views/ConfigView.js
+++ b/slicer_cli_web/web_client/views/ConfigView.js
@@ -84,7 +84,7 @@ const ConfigView = View.extend({
         const name = data.get('name').split(',').map((d) => d.trim()).filter((d) => d.length > 0);
         return restRequest({
             type: 'PUT',
-            url: 'slicer_cli_web/slicer_cli_web/docker_image',
+            url: 'slicer_cli_web/docker_image',
             data: {
                 name: JSON.stringify(name),
                 folder: data.get('folder')

--- a/slicer_cli_web/web_client/views/ItemView.js
+++ b/slicer_cli_web/web_client/views/ItemView.js
@@ -19,9 +19,6 @@ wrap(ItemView, 'render', function (render) {
         if (this.model.get('meta').slicerCLIType !== 'task') {
             return;
         }
-        if (!this.model.parent || !this.model.parent.get('meta').slicerCLIRestPath) {
-            return;
-        }
         this.slicerCLIPanel = new SlicerUI({
             el: $('<div>', { class: 'g-item-slicer-ui' })
                 .insertAfter(this.$('.g-item-info')),
@@ -42,7 +39,6 @@ const SlicerUI = View.extend({
         this._panelViews = {};
 
         this.taskModel = settings.taskModel;
-        this.restPath = `${this.taskModel.parent.get('meta').slicerCLIRestPath}/${this.taskModel.get('name')}`;
 
         this.loadModel();
     },
@@ -133,7 +129,7 @@ const SlicerUI = View.extend({
 
         // post the job to the server
         restRequest({
-            url: `slicer_cli_web/${this.restPath}/run`,
+            url: `slicer_cli_web/slicer_cli_web/cli/${this.taskModel.id}/run`,
             method: 'POST',
             data: params
         }).then((data) => {

--- a/slicer_cli_web/web_client/views/ItemView.js
+++ b/slicer_cli_web/web_client/views/ItemView.js
@@ -129,7 +129,7 @@ const SlicerUI = View.extend({
 
         // post the job to the server
         restRequest({
-            url: `slicer_cli_web/slicer_cli_web/cli/${this.taskModel.id}/run`,
+            url: `slicer_cli_web/cli/${this.taskModel.id}/run`,
             method: 'POST',
             data: params
         }).then((data) => {

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -56,7 +56,7 @@ class ImageHelper(object):
             assert key not in obj
 
     def getEndpoint(self):
-        resp = self.server.request(path='/slicer_cli_web/slicer_cli_web/docker_image',
+        resp = self.server.request(path='/slicer_cli_web/docker_image',
                                    user=self.admin)
         assertStatus(resp, 200)
 
@@ -129,7 +129,7 @@ class ImageHelper(object):
             events.bind('jobs.job.update.after', 'slicer_cli_web_del',
                         self.delHandler)
 
-        resp = self.server.request(path='/slicer_cli_web/slicer_cli_web/docker_image',
+        resp = self.server.request(path='/slicer_cli_web/docker_image',
                                    user=self.admin, method='DELETE',
                                    params={'name': json.dumps(name),
                                            'delete_from_local_repo':
@@ -183,7 +183,7 @@ class ImageHelper(object):
                         'slicer_cli_web_add', self.addHandler)
 
         resp = self.server.request(
-            path='/slicer_cli_web/slicer_cli_web/docker_image',
+            path='/slicer_cli_web/docker_image',
             user=self.admin, method='PUT', params={'name': json.dumps(name),
                                                    'folder': self.folder['_id']},
             isJson=initialStatus == 200)
@@ -233,7 +233,7 @@ def testDockerAdd(images):
 def testDockerAddBadParam(server, admin, folder):
     # test sending bad parameters to the PUT endpoint
     kwargs = {
-        'path': '/slicer_cli_web/slicer_cli_web/docker_image',
+        'path': '/slicer_cli_web/docker_image',
         'user': admin,
         'method': 'PUT',
         'params': {'name': json.dumps(6), 'folder': folder['_id']}

--- a/tests/test_rest_slicer_cli.py
+++ b/tests/test_rest_slicer_cli.py
@@ -77,15 +77,15 @@ class TestClass:
 
         girderCLIItem = Item().createItem('data', admin, folder)
         Item().setMetadata(girderCLIItem, dict(slicerCLIType='task', type='python',
+                                               image='dockerImage', digest='dockerImage@sha256:abc',
                                                xml=open(xmlpath, 'rb').read()))
 
         resource = docker_resource.DockerResource('test')
         item = CLIItem(girderCLIItem)
-        handlerFunc = rest_slicer_cli.genHandlerToRunDockerCLI(
-            'dockerImage', 'dockerImage@sha256:abc', item, resource)
+        handlerFunc = rest_slicer_cli.genHandlerToRunDockerCLI(item)
         assert handlerFunc is not None
 
-        job = handlerFunc(params={
+        job = handlerFunc(resource, params={
             'inputImageFile': str(file['_id']),
             'secondImageFile': str(file['_id']),
             'outputStainImageFile_1_folder': str(folder['_id']),
@@ -102,8 +102,6 @@ class TestClass:
         assert 'container_args' in kwargs
         assert 'image' in kwargs
         assert 'pull_image' in kwargs
-
-        print(kwargs)
 
         assert kwargs['image'] == 'dockerImage@sha256:abc'
         assert kwargs['pull_image'] == 'if-not-present'


### PR DESCRIPTION
closes #85 and closes #90 

notes
 * please reimport your tasks to take effect
 * I create a new generic set of end points at `slicer_cli_web/cli` in which the item based tasks can be accessed more easily
 * I managed to implement the task in any subdirectory lookup mostly in mongo directly. In the end two queries (first retrieve all directories in folder, second query all items in these folders) are used

