### PR TITLE
Improve feedback

### DIFF
--- a/slicer_cli_web/web_client/stylesheets/controlWidget.styl
+++ b/slicer_cli_web/web_client/stylesheets/controlWidget.styl
@@ -9,3 +9,17 @@
 .s-control-item
   input.form-control
     height auto
+  
+    
+.has-error
+  .control-label::before 
+    font-family: "Glyphicons Halflings";
+    content: "\e101";
+    color: #a94442;
+    margin-right: 5px;
+    vertical-align: text-top;
+  .form-control
+    background-color: #f2dede
+    border-color: #ebccd1
+    ::placeholder
+      color:#a94442 

--- a/slicer_cli_web/web_client/stylesheets/controlWidget.styl
+++ b/slicer_cli_web/web_client/stylesheets/controlWidget.styl
@@ -1,14 +1,14 @@
 .s-control-widget-label
-  margin-bottom: 2px
+  margin-bottom 2px
 
 .s-control-widget-description
-  font-size: 12px
-  color: #666
-  margin-bottom: 4px
+  font-size 12px
+  color #666
+  margin-bottom 4px
 
 .s-control-item
   input.form-control
-    height: auto
+    height auto
       
 .has-error
   .s-control-widget-label::before,
@@ -17,10 +17,10 @@
   .checkbox-inline::before,
   .radio-inline::before
     color:#a94442
-    content: "\e101"
-    font-family: "Glyphicons Halflings"
-    margin-right: 5px
-    vertical-align: text-top
+    content "\e101"
+    font-family "Glyphicons Halflings"
+    margin-right 5px
+    vertical-align text-top
   .form-control
     background-color:#f2dede
     border-color:#ebccd1

--- a/slicer_cli_web/web_client/stylesheets/controlWidget.styl
+++ b/slicer_cli_web/web_client/stylesheets/controlWidget.styl
@@ -1,25 +1,29 @@
 .s-control-widget-label
-  margin-bottom 2px
+  margin-bottom: 2px
 
 .s-control-widget-description
-  font-size 12px
-  color #666
-  margin-bottom 4px
+  font-size: 12px
+  color: #666
+  margin-bottom: 4px
 
 .s-control-item
   input.form-control
-    height auto
-  
-    
+    height: auto
+      
 .has-error
-  .control-label::before 
-    font-family: "Glyphicons Halflings";
-    content: "\e101";
-    color: #a94442;
-    margin-right: 5px;
-    vertical-align: text-top;
+  .s-control-widget-label::before,
+  .checkbox::before,
+  .radio::before,
+  .checkbox-inline::before,
+  .radio-inline::before
+    color:#a94442
+    content: "\e101"
+    font-family: "Glyphicons Halflings"
+    margin-right: 5px
+    vertical-align: text-top
   .form-control
-    background-color: #f2dede
-    border-color: #ebccd1
+    background-color:#f2dede
+    border-color:#ebccd1
+    color:#a94442
     ::placeholder
-      color:#a94442 
+      color:#a94442

--- a/slicer_cli_web/web_client/stylesheets/controlWidget.styl
+++ b/slicer_cli_web/web_client/stylesheets/controlWidget.styl
@@ -16,14 +16,14 @@
   .radio::before,
   .checkbox-inline::before,
   .radio-inline::before
-    color:#a94442
+    color #a94442
     content "\e101"
     font-family "Glyphicons Halflings"
     margin-right 5px
     vertical-align text-top
   .form-control
-    background-color:#f2dede
-    border-color:#ebccd1
-    color:#a94442
+    background-color #f2dede
+    border-color #ebccd1
+    color #a94442
     ::placeholder
-      color:#a94442
+      color #a94442


### PR DESCRIPTION
Adds bootstrap alert glyphicons to the front of the Label for the element which is invalidated.
Colors input text fields a darker red to indicate they have an issue.
For check boxes and radio buttons it will place the glyphicon in front of the interaction.
This follows the previous alert convention while providing more visibility.

resolves #114 
