### PR TITLE
Task upload button injecting and authentication

### DIFF
--- a/slicer_cli_web/web_client/stylesheets/controlWidget.styl
+++ b/slicer_cli_web/web_client/stylesheets/controlWidget.styl
@@ -16,7 +16,7 @@
   .radio::before,
   .checkbox-inline::before,
   .radio-inline::before
-    color:#a94442
+    color #a94442
     content "\e101"
     font-family "Glyphicons Halflings"
     margin-right 5px
@@ -24,6 +24,6 @@
   .form-control
     background-color:#f2dede
     border-color:#ebccd1
-    color:#a94442
+    color #a94442
     ::placeholder
-      color:#a94442
+      color #a94442

--- a/slicer_cli_web/web_client/views/CollectionView.js
+++ b/slicer_cli_web/web_client/views/CollectionView.js
@@ -29,16 +29,14 @@ wrap(HierarchyWidget, 'render', function (render) {
             });
     };
 
-    if (getCurrentUser()) {
-        if (getCurrentUser().get('admin') === true){
-            if (this.parentModel.get('_modelType') === 'folder') {
-                ConfigView.getSettings().then((settings) => {
-                    if (settings.task_folder === this.parentModel.id) {
-                        injectUploadImageButton();
-                    }
-                    return null;
-                });
-            }
+    if (getCurrentUser() && getCurrentUser().get('admin')) {
+        if (this.parentModel.get('_modelType') === 'folder') {
+            ConfigView.getSettings().then((settings) => {
+                if (settings.task_folder === this.parentModel.id) {
+                    injectUploadImageButton();
+                }
+                return null;
+            });
         }
     }
 });

--- a/slicer_cli_web/web_client/views/CollectionView.js
+++ b/slicer_cli_web/web_client/views/CollectionView.js
@@ -2,8 +2,8 @@ import $ from 'jquery';
 import { wrap } from '@girder/core/utilities/PluginUtils';
 import { restRequest } from '@girder/core/rest';
 import View from '@girder/core/views/View';
-import CollectionView from '@girder/core/views/body/CollectionView';
 import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import { getCurrentUser } from '@girder/core/auth';
 
 import UploadImageDialogTemplate from '../templates/uploadImageDialog.pug';
 import { showJobSuccessAlert } from './utils';
@@ -29,13 +29,15 @@ wrap(HierarchyWidget, 'render', function (render) {
             });
     };
 
-    if ((this.parentView instanceof CollectionView && this.parentModel.get('_modelType') === 'folder')) {
-        ConfigView.getSettings().then((settings) => {
-            if (settings.task_folder === this.parentModel.id) {
-                injectUploadImageButton();
-            }
-            return null;
-        });
+    if ((getCurrentUser() || {}).get('admin') === true) {
+        if (this.parentModel.get('_modelType') === 'folder') {
+            ConfigView.getSettings().then((settings) => {
+                if (settings.task_folder === this.parentModel.id) {
+                    injectUploadImageButton();
+                }
+                return null;
+            });
+        }
     }
 });
 

--- a/slicer_cli_web/web_client/views/CollectionView.js
+++ b/slicer_cli_web/web_client/views/CollectionView.js
@@ -29,14 +29,16 @@ wrap(HierarchyWidget, 'render', function (render) {
             });
     };
 
-    if ((getCurrentUser() || {}).get('admin') === true) {
-        if (this.parentModel.get('_modelType') === 'folder') {
-            ConfigView.getSettings().then((settings) => {
-                if (settings.task_folder === this.parentModel.id) {
-                    injectUploadImageButton();
-                }
-                return null;
-            });
+    if (getCurrentUser()) {
+        if (getCurrentUser().get('admin') === true){
+            if (this.parentModel.get('_modelType') === 'folder') {
+                ConfigView.getSettings().then((settings) => {
+                    if (settings.task_folder === this.parentModel.id) {
+                        injectUploadImageButton();
+                    }
+                    return null;
+                });
+            }
         }
     }
 });

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -6,6 +6,7 @@ from pytest_girder.web_client import runWebClientTest
 @pytest.mark.plugin('slicer_cli_web')
 @pytest.mark.parametrize('spec', (
     'configViewSpec.js',
+    'containerViewSpec.js',
     'dockerTaskSpec.js',
     'panelGroupSpec.js',
     'parseSpec.js',

--- a/tests/web_client_specs/containerViewSpec.js
+++ b/tests/web_client_specs/containerViewSpec.js
@@ -89,8 +89,7 @@ function navigateToCollectionsFolder(collectionName, folderName)
     waitsFor(function () {
         return $('.g-collection-create-button').length > 0;
     }, 'collection list screen to load');
-
-    girderTest.waitForLoad();
+    girderTest.waitForLoad();    
     waitsFor(function () {
         return $('.g-collection-list-entry').length > 0;
     }, 'collection list to load');
@@ -99,8 +98,8 @@ function navigateToCollectionsFolder(collectionName, folderName)
     runs(function () {
         $('.g-collection-link:contains('+collectionName+')').first().click();
     });
-
     girderTest.waitForLoad();
+
     waitsFor(function () {
         return $('.g-folder-list-link').length > 0;
     }, 'the folder list to load');
@@ -111,10 +110,8 @@ function navigateToCollectionsFolder(collectionName, folderName)
 }
 
 $(function () {
-    describe('UploadDockerImages button and functionality', function () {
-       
-        it('login, setup collection/folder and navigate to it', function () {
-            
+    describe('UploadDockerImages button and functionality', function () {       
+        it('login, setup collection/folder and navigate to it', function () {            
             login('admin', 'password');
             createDefaultTaskFolder("Tasks","Default Tasks", true, "Slicer CLI Web Tasks");
             navigateToCollectionsFolder("Tasks","Slicer CLI Web Tasks");
@@ -144,8 +141,7 @@ $(function () {
                 $("#g-slicer-cli-web-upload-form button.close").click();
             }, "wait for dialog to close");
         });      
-  
-        //Now lets test to make sure a standard user without admin privileges can't view the button
+          
         it('logout from admin account', girderTest.logout());
         it('register a (normal user)',
         girderTest.createUser('johndoe',

--- a/tests/web_client_specs/containerViewSpec.js
+++ b/tests/web_client_specs/containerViewSpec.js
@@ -8,78 +8,56 @@ girderTest.promise.done(function () {
 
 girderTest.startApp();
 
-function login(user, password) {
-    girderTest.waitForLoad('login wait 1');
-    runs(function () {
-        $('.g-login').click();
-    });
-
-    girderTest.waitForDialog('login wait 2');
-    runs(function () {
-        $('#g-login').val(user || 'user');
-        $('#g-password').val(password || 'password');
-        $('#g-login-button').click();
-    });
-
-    waitsFor(function () {
-        return $('.g-user-dropdown-link').length > 0;
-    }, 'user to be logged in');
-    girderTest.waitForLoad('login wait 3');
-}
-
-//Creates container and Default Task Folder and sets it in the settings using REST
-function createDefaultTaskFolder(name, description, public, folder){
+// Creates container and Default Task Folder and sets it in the settings using REST
+function createDefaultTaskFolder(name, description, folder) {
     var collectionID = false;
-    waitsFor(function () {
+    runs(function () {
         var resp = girder.rest.restRequest({
             url: '/collection',
             method: 'POST',
             data: {
                 name: name,
-                description:description,
-                public:public
+                description: description,
+                public: true
             },
             async: false
         });
-        collectionID = resp.responseJSON["_id"];
+        collectionID = resp.responseJSON._id;
         return resp && resp.responseJSON;
-
-    }, "Creating Collection");
+    }, 'Creating Collection');
 
     var folderID = false;
-    waitsFor(function () {
+    runs(function () {
         var resp = girder.rest.restRequest({
             url: '/folder',
             method: 'POST',
             data: {
                 name: folder,
-                parentType:"collection",
-                parentId:collectionID,
-                public:public
+                parentType: 'collection',
+                parentId: collectionID,
+                public: true
             },
             async: false
         });
-        folderID = resp.responseJSON["_id"];
+        folderID = resp.responseJSON._id;
         return resp && resp.responseJSON;
+    }, 'Creating SubFolder');
 
-    }, "Creating SubFolder");
-
-    waitsFor(function () {
+    runs(function () {
         var resp = girder.rest.restRequest({
             url: '/system/setting',
             method: 'PUT',
             data: {
-                key: "slicer_cli_web.task_folder",
-                value:folderID
+                key: 'slicer_cli_web.task_folder',
+                value: folderID
             },
             async: false
-        })
+        });
         return resp && resp.responseJSON;
-    }, "Setting Default Task Folder");    
+    }, 'Setting Default Task Folder');
 }
 
-function navigateToCollectionsFolder(collectionName, folderName)
-{
+function navigateToCollectionsFolder(collectionName, folderName) {
     waitsFor(function () {
         return $('a.g-nav-link[g-target="collections"]').length > 0;
     }, 'collection list link to load');
@@ -89,14 +67,14 @@ function navigateToCollectionsFolder(collectionName, folderName)
     waitsFor(function () {
         return $('.g-collection-create-button').length > 0;
     }, 'collection list screen to load');
-    girderTest.waitForLoad();    
+    girderTest.waitForLoad();
     waitsFor(function () {
         return $('.g-collection-list-entry').length > 0;
     }, 'collection list to load');
 
-    //NOTE: This is equivalent to indexOf, can have multiple matches
+    // NOTE: This is equivalent to indexOf, can have multiple matches
     runs(function () {
-        $('.g-collection-link:contains('+collectionName+')').first().click();
+        $('.g-collection-link:contains(' + collectionName + ')').first().click();
     });
     girderTest.waitForLoad();
 
@@ -104,56 +82,55 @@ function navigateToCollectionsFolder(collectionName, folderName)
         return $('.g-folder-list-link').length > 0;
     }, 'the folder list to load');
     runs(function () {
-        $('.g-folder-list-link:contains('+folderName+')').first().click();
-    });   
+        $('.g-folder-list-link:contains(' + folderName + ')').first().click();
+    });
     girderTest.waitForLoad();
 }
 
-$(function () {
-    describe('UploadDockerImages button and functionality', function () {       
-        it('login, setup collection/folder and navigate to it', function () {            
-            login('admin', 'password');
-            createDefaultTaskFolder("Tasks","Default Tasks", true, "Slicer CLI Web Tasks");
-            navigateToCollectionsFolder("Tasks","Slicer CLI Web Tasks");
-        });
+describe('UploadDockerImages button and functionality', function () {
+    it('login, setup collection/folder and navigate to it', function () {
+        it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'password'));
+        createDefaultTaskFolder('Tasks', 'Default Tasks', true, 'Slicer CLI Web Tasks');
+        navigateToCollectionsFolder('Tasks', 'Slicer CLI Web Tasks');
+    });
 
-        it('check docker task image upload button', function () {
-            waitsFor(function () {                
-                return ($('.g-upload-slicer-cli-task-button').length > 0);
-            }, "upload docker image button to be visible");
-            runs(function () {                
-                expect($('.g-upload-slicer-cli-task-button').length > 0);
-            });
+    it('check docker task image upload button', function () {
+        waitsFor(function () {
+            return ($('.g-upload-slicer-cli-task-button').length > 0);
+        }, 'upload docker image button to be visible');
+        runs(function () {
+            expect($('.g-upload-slicer-cli-task-button').length > 0);
         });
+    });
 
-        it('test the upload docker image button', function () {
-            runs(function () {
-                $('.g-upload-slicer-cli-task-button').click();
-            })
-            waitsFor(function () {
-                return ($('#g-slicer-cli-web-image').length > 0);
-            })
-            girderTest.waitForDialog();
-            runs(function () {
-                expect($('#g-slicer-cli-web-image').length > 0);
-            }, 'the modal dialog to load');
-            runs(function () {
-                $("#g-slicer-cli-web-upload-form button.close").click();
-            }, "wait for dialog to close");
-        });      
-          
-        it('logout from admin account', girderTest.logout());
-        it('register a (normal user)',
+    it('test the upload docker image button', function () {
+        runs(function () {
+            $('.g-upload-slicer-cli-task-button').click();
+        });
+        waitsFor(function () {
+            return ($('#g-slicer-cli-web-image').length > 0);
+        });
+        girderTest.waitForDialog();
+        runs(function () {
+            expect($('#g-slicer-cli-web-image').length > 0);
+        }, 'the modal dialog to load');
+        runs(function () {
+            $('#g-slicer-cli-web-upload-form button.close').click();
+        }, 'wait for dialog to close');
+        girderTest.waitForLoad();
+    });
+
+    it('logout from admin account', girderTest.logout());
+    it('register a (normal user)',
         girderTest.createUser('johndoe',
             'john.doe@girder.test',
             'John',
             'Doe',
             'password!'));
-        it('navigate to task folder and check icon',function () {
-            navigateToCollectionsFolder("Tasks","Slicer CLI Web Tasks");
-            runs(function () {                
-                expect($('.g-upload-slicer-cli-task-button').length === 0);
-            });            
-        });               
-    })
+    it('navigate to task folder and check icon', function () {
+        navigateToCollectionsFolder('Tasks', 'Slicer CLI Web Tasks');
+        runs(function () {
+            expect($('.g-upload-slicer-cli-task-button').length === 0);
+        });
+    });
 });

--- a/tests/web_client_specs/containerViewSpec.js
+++ b/tests/web_client_specs/containerViewSpec.js
@@ -89,8 +89,8 @@ function navigateToCollectionsFolder(collectionName, folderName) {
 
 describe('UploadDockerImages button and functionality', function () {
     it('login, setup collection/folder and navigate to it', function () {
-        it('Login as admin', girderTest.login('admin', 'Admin', 'Admin', 'password'));
-        createDefaultTaskFolder('Tasks', 'Default Tasks', true, 'Slicer CLI Web Tasks');
+        girderTest.login('admin', 'Admin', 'Admin', 'password')();
+        createDefaultTaskFolder('Tasks', 'Default Tasks', 'Slicer CLI Web Tasks');
         navigateToCollectionsFolder('Tasks', 'Slicer CLI Web Tasks');
     });
 


### PR DESCRIPTION
- Ensures that the task upload button is only visible for admins.  Previously it was visible for users but attempting to upload would fail.  
- Updated the default task upload location to be set to user folders instead of just collections
- Added test coverage for collectionView and task button

resolves #113 
