### PR TITLE
Make the GET docker_image endpoint public.

### DIFF
--- a/slicer_cli_web/docker_resource.py
+++ b/slicer_cli_web/docker_resource.py
@@ -59,23 +59,24 @@ class DockerResource(Resource):
 
         self._generateAllItemEndPoints()
 
-    @access.user
+    @access.public
     @describeRoute(
         Description('List docker images and their CLIs')
-        .errorResponse('You are not logged in.', 403)
+        .notes('You must be logged in to see any results.')
     )
     def getDockerImages(self, params):
         data = {}
-        for image in DockerImageItem.findAllImages(self.getCurrentUser()):
-            imgData = {}
-            for cli in image.getCLIs():
-                basePath = '/%s/cli/%s' % (self.resourceName, cli._id)
-                imgData[cli.name] = {
-                    'type': cli.type,
-                    'xmlspec': basePath + '/xml',
-                    'run': basePath + '/run'
-                }
-            data.setdefault(image.image, {})[image.tag] = imgData
+        if self.getCurrentUser():
+            for image in DockerImageItem.findAllImages(self.getCurrentUser()):
+                imgData = {}
+                for cli in image.getCLIs():
+                    basePath = '/%s/cli/%s' % (self.resourceName, cli._id)
+                    imgData[cli.name] = {
+                        'type': cli.type,
+                        'xmlspec': basePath + '/xml',
+                        'run': basePath + '/run'
+                    }
+                data.setdefault(image.image, {})[image.tag] = imgData
         return data
 
     @access.admin

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -218,13 +218,17 @@ def testAddNonExistentImage(images):
 
 
 @pytest.mark.plugin('slicer_cli_web')
-def testDockerAdd(images):
+def testDockerAdd(images, server):
     # try to cache a good image to the mongo database
     img_name = 'girder/slicer_cli_web:small'
     images.assertNoImages()
     images.addImage(img_name, JobStatus.SUCCESS)
     images.imageIsLoaded(img_name, True)
-    # images.endpointsExist(img_name, ['Example1', 'Example2'], ['Example3'])
+    # If checked without a user, we should get an empty list
+    resp = server.request(path='/slicer_cli_web/docker_image')
+    assertStatus(resp, 200)
+    assert json.loads(getResponseBody(resp)) == {}
+    images.endpointsExist(img_name, ['Example1', 'Example2', 'Example3'], ['NotAnExample'])
     images.deleteImage(img_name, True)
     images.assertNoImages()
 


### PR DESCRIPTION
If there is no user, an empty result set is returned.  This prevents asking for a login during anonymous usage.