### PR TITLE
Support defaultNameMatch and defaultPathMatch attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,7 @@ commands:
           command: pip install codecov==2.1.9
       - run:
           name: Upload coverage
-          # Retry as codecov can be flaky
-          command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --required --disable search pycov gcov --root project --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
+          command: codecov --tries 10 --required --disable search pycov gcov --root project --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml
 
 jobs:
   py27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,181 +1,150 @@
 version: 2.1
 
+executors:
+  toxandnode:
+    working_directory: ~/project
+    docker:
+      - image: girder/tox-and-node
+      - image: circleci/mongo:4.0-ram
+      - image: rabbitmq
 commands:
-  upload:
-    parameters:
-      conf:
-        description: Used to specify the location of the .codecov.yml config file
-        type: string
-        default: ".codecov.yml"
-      file:
-        description: Path to the code coverage data file to upload.
-        type: string
-        default: ""
-      flags:
-        description: Flag the upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
-        type: string
-        default: ""
-      token:
-        description: Set the private repository token (defaults to environment variable $CODECOV_TOKEN)
-        type: string
-        default: ${CODECOV_TOKEN}
-      upload_name:
-        description: Custom defined name of the upload. Visible in Codecov UI
-        type: string
-        default: ${CIRCLE_BUILD_NUM}
-      url:
-        description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
-        type: string
-        default: "https://codecov.io/bash"
-      when:
-        description: When should this step run?
-        type: string
-        default: "always"
-    steps:
-      - when:
-          condition: << parameters.file >>
-          steps:
-            - run:
-                name: Upload Coverage Results
-                command: |
-                  curl -s << parameters.url >> | bash -s -- \
-                    -f "<< parameters.file >>" \
-                    -t "<< parameters.token >>" \
-                    -n "<< parameters.upload_name >>" \
-                    -y "<< parameters.conf >>" \
-                    -F "<< parameters.flags >>" \
-                    -Z || echo 'Codecov upload failed'
-                when: << parameters.when >>
-      - unless:
-          condition: << parameters.file >>
-          steps:
-            - run:
-                name: Upload Coverage Results
-                command: |
-                  curl -s << parameters.url >> | bash -s -- \
-                    -t "<< parameters.token >>" \
-                    -n "<< parameters.upload_name >>" \
-                    -y "<< parameters.conf >>" \
-                    -F "<< parameters.flags >>" \
-                    -Z || echo 'Codecov upload failed'
-                when: << parameters.when >>
   tox:
-    description: "run tox"
+    description: "Run tox"
     parameters:
       env:
         type: string
     steps:
       - run:
-          name: Upgrade Pip
-          command: pip install -U pip
+          name: Preinstall phantomjs to work around an npm permission issue
+          command: npm install -g phantomjs-prebuilt --unsafe-perm
       - run:
           name: Run tests via tox
           # Piping through cat does less buffering of the output but can
           # consume the exit code
-          command: tox -e << parameters.env >>  | cat; test ${PIPESTATUS[0]} -eq 0
-
-executors:
-  py2:
-    working_directory: ~/project
-    docker:
-      - image: girder/girder_test:latest-py2
-      - image: circleci/mongo:3.4-ram
-        # storage engine. We can pass alternate options to "mongod" by overwriting the default "CMD"
-        # used to start the Docker image: https://github.com/circleci/circleci-images/blob/master/mongo/resources/Dockerfile-ram.template
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
-      - image: rabbitmq
-  py3:
-    working_directory: ~/project
-    docker:
-      - image: girder/girder_test:latest-py3
-      - image: circleci/mongo:3.4-ram
-        command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
-      - image: rabbitmq
+          command: tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+  coverage:
+    description: "Upload coverage"
+    steps:
+      - run:
+          name: Install Codecov client
+          command: pip install codecov==2.1.9
+      - run:
+          name: Upload coverage
+          # Retry as codecov can be flaky
+          command: for i in $(seq 1 10); do [ $i -gt 1 ] && echo "retrying $i" && sleep 5; codecov --required --disable search pycov gcov --root project --file .tox/coverage/py_coverage.xml .tox/coverage/cobertura-coverage.xml && s=0 && break || s=$?; done; (exit $s)
 
 jobs:
-  lint:
-    executor: py3
+  py27:
+    executor: toxandnode
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py27
+      - coverage
+  py36:
+    executor: toxandnode
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py36
+      - coverage
+  py37:
+    executor: toxandnode
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py37
+      - coverage
+  py38:
+    executor: toxandnode
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py38
+      - coverage
+  py39:
+    executor: toxandnode
+    steps:
+      - checkout
+      - setup_remote_docker
+      - tox:
+          env: py39
+      - coverage
+  lint_and_docs:
+    executor: toxandnode
     steps:
       - checkout
       - tox:
           env: flake8,lintclient
-  py27:
-    executor: py2
+  release:
+    docker:
+      - image: girder/tox-and-node
     steps:
       - checkout
-      - setup_remote_docker
-      - run:
-          name: Install Python headers
-          command: |
-            sudo apt-get install python-dev
-      - tox:
-          env: py27
-  py36:
-    executor: py3
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Install Python headers
-          command: |
-            sudo apt-get install python3-dev
-      - tox:
-          env: py36
-  py37:
-    executor: py3
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Install Python headers
-          command: |
-            sudo apt-get install python3-dev
-      - tox:
-          env: py37
-      - upload:
-          file: .tox/coverage/py_coverage.xml
-          flags: backend
-      - upload:
-          file: build/test/coverage/web_temp/*.json
-          flags: ui
-      - store_test_results:
-          path: build/test-reports
-      - store_artifacts:
-          path: build/test-reports
-  deploy:
-    executor: py3
-    steps:
-      - checkout
-      - setup_remote_docker
       - deploy:
-          command: tox -e release
+          name: Run tests via tox
+          # Piping through cat does less buffering of the output but can
+          # consume the exit code
+          command: PYTEST_ADDOPTS=--forked tox -e release | cat; test ${PIPESTATUS[0]} -eq 0
 
 workflows:
   version: 2
   ci:
     jobs:
-      - lint:
-          filters:
-            tags:
-              only: /^v.*/
       - py27:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - py36:
           filters:
             tags:
               only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - py37:
           filters:
             tags:
               only: /^v.*/
-      - deploy:
+            branches:
+              ignore:
+                - gh-pages
+      - py38:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
+      - py39:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
+      - lint_and_docs:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
+      - release:
           requires:
-            - lint
             - py27
             - py36
             - py37
+            - py38
+            - py39
+            - lint_and_docs
           filters:
             tags:
               only: /^v.*/

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,8 @@ The XML must conform to the `Slicer Execution Schema <https://www.slicer.org/w/i
 
 - The ``region`` type can have a ``coordinateSystem`` property.
 
+- Some input types (``image``, ``file``, ``item``, ``directory``) can have ``defaultNameMatch`` and ``defaultPathMatch`` properties.  These are regular expressions designed to give a UI a value to match to prepopulate default values from files or paths that match the regex.  ``defaultNameMatch`` is intended to match the final path element, whereas ``defaultPathMatch`` is used on the entire path as a combined string.
+
 
 .. |build-status| image:: https://circleci.com/gh/girder/slicer_cli_web.svg?style=svg
     :target: https://circleci.com/gh/girder/slicer_cli_web

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -34,7 +35,7 @@ setup(
     keywords='girder-plugin, slicer_cli_web',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
-    license='Apache 2.0',
+    license='Apache Software License 2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -47,6 +48,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     include_package_data=True,
     package_dir={'girder_slicer_cli_web': 'slicer_cli_web'},
@@ -61,8 +64,8 @@ setup(
     extras_require={
         'girder': [
             'docker>=2.6.0',
-            'girder>=3.0.3',
-            'girder-jobs>=3.0.3',
+            'girder>=3.0.4' + (',<=3.1.0' if sys.version_info < (3, 6) else ''),
+            'girder-jobs>=3.0.3' + (',<=3.1.0' if sys.version_info < (3, 6) else ''),
             'girder-worker[girder]>=0.6.0',
         ],
         'worker': [
@@ -77,5 +80,6 @@ setup(
         'girder_worker_plugins': [
             'slicer_cli_web = slicer_cli_web.girder_worker_plugin:SlicerCLIWebWorkerPlugin'
         ]
-    }
+    },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 )

--- a/slicer_cli_web/ctk_cli_adjustment.py
+++ b/slicer_cli_web/ctk_cli_adjustment.py
@@ -8,104 +8,145 @@ ctk_cli.module.CLIConstraints.OPTIONAL_ELEMENTS = (
 ctk_cli.module.CLIConstraints.REQUIRED_ELEMENTS = ()
 
 
-# This is copied from ctk_cli/module.py with a few changes
+class CLIParameter(ctk_cli.module.CLIParameter):
+    REQUIRED_ELEMENTS = ('name', 'description', 'label')
+
+    OPTIONAL_ELEMENTS = (  # either 'index' or at least one of 'flag' or 'longflag' is required
+        'flag', 'longflag', 'index',
+        'default', 'channel')
+
+    __slots__ = ('typ', 'hidden', '_pythonType') + REQUIRED_ELEMENTS + OPTIONAL_ELEMENTS + (
+        'constraints',  # scalarVectorType, scalarType
+        'multiple',  # multipleType
+        'elements',  # enumerationType
+        'coordinateSystem',  # pointType, pointFileType
+        'fileExtensions',  # fileType
+        'reference',  # imageType, transformType, geometryType, tableType
+        'subtype',  # 'type' of imageType / geometryType
+        'defaultPathMatch',
+        'defaultNameMatch',
+    )
+
+    # This is copied from ctk_cli/module.py with a few changes
+    @classmethod  # noqa
+    def parse(cls, elementTree):  # noqa
+        assert ctk_cli.module._tag(elementTree) in cls.TYPES, '%s not in CLIParameter.TYPES' % ctk_cli.module._tag(elementTree)  # noqa
+
+        self = cls()
+        self.typ = ctk_cli.module._tag(elementTree)
+
+        if self.typ in ('point', 'region'):
+            self._pythonType = float
+        else:
+            elementType = self.typ
+            if elementType.endswith('-vector'):
+                elementType = elementType[:-7]
+            elif elementType.endswith('-enumeration'):
+                elementType = elementType[:-12]
+            self._pythonType = self.PYTHON_TYPE_MAPPING.get(elementType, str)
+
+        self.hidden = ctk_cli.module._parseBool(elementTree.get('hidden', 'false'))
+
+        self.constraints = None
+        self.multiple = None
+        self.elements = None
+        self.coordinateSystem = None
+        self.fileExtensions = None
+        # Added defaultPathMatch, defaultNameMatch (slicer_cli_web)
+        self.defaultPathMatch = None
+        self.defaultNameMatch = None
+        self.reference = None
+        self.subtype = None
+
+        for key, value in elementTree.items():
+            if key == 'multiple':
+                self.multiple = ctk_cli.module._parseBool(value)
+            # Added region (slicer_cli_web)
+            elif key == 'coordinateSystem' and self.typ in ('point', 'pointfile', 'region'):
+                self.coordinateSystem = value
+            elif key == 'fileExtensions':
+                self.fileExtensions = [ext.strip() for ext in value.split(',')]
+            # Added defaultPathMatch, defaultNameMatch (slicer_cli_web)
+            elif key == 'defaultPathMatch':
+                self.defaultPathMatch = value
+            elif key == 'defaultNameMatch':
+                self.defaultNameMatch = value
+            # Added file (slicer_cli_web)
+            elif key == 'reference' and self.typ in ('image', 'file', 'transform', 'geometry', 'table'):  # noqa
+                self.reference = value
+                # Suppressed warning (slicer_cli_web)
+                # ctk_cli.module.logger.warning("'reference' attribute of %r is not part of the spec yet (CTK issue #623)" % (ctk_cli.module._tag(elementTree), ))  # noqa
+            elif key == 'type':
+                self.subtype = value
+            elif key != 'hidden':
+                ctk_cli.module.logger.warning('attribute of %r ignored: %s=%r' % (ctk_cli.module._tag(elementTree), key, value))  # noqa
+
+        elements = []
+
+        childNodes = ctk_cli.module._parseElements(self, elementTree)
+        for n in childNodes:
+            if ctk_cli.module._tag(n) == 'constraints':
+                self.constraints = ctk_cli.module.CLIConstraints.parse(n)
+            elif ctk_cli.module._tag(n) == 'element':
+                if not n.text:
+                    ctk_cli.module.logger.warning("Ignoring empty <element> within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+                else:
+                    elements.append(n.text)
+            else:
+                ctk_cli.module.logger.warning("Element %r within %r not parsed" % (ctk_cli.module._tag(n), ctk_cli.module._tag(elementTree)))  # noqa
+
+        # Added channel and external type checks (slicer_cli_web)
+        if (not self.flag and not self.longflag and self.index is None and
+                (self.channel != 'output' or self.isExternalType())):
+            ctk_cli.module.logger.warning("Parameter %s cannot be passed (missing one of flag, longflag, or index)!" % (  # noqa
+                self.identifier(), ))
+
+        if self.flag and not self.flag.startswith('-'):
+            self.flag = '-' + self.flag
+        if self.longflag and not self.longflag.startswith('-'):
+            self.longflag = '--' + self.longflag
+
+        if self.index is not None:
+            self.index = int(self.index)
+
+        if self.default:
+            try:
+                self.default = self.parseValue(self.default)
+            except ValueError as e:
+                ctk_cli.module.logger.warning('Could not parse default value of <%s> (%s): %s' % (
+                    ctk_cli.module._tag(elementTree), self.name, e))
+
+        if self.typ.endswith('-enumeration'):
+            try:
+                self.elements = list(map(self.parseValue, elements))
+            except ValueError as e:
+                ctk_cli.module.logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (  # noqa
+                    ctk_cli.module._tag(elementTree), self.name, e))
+            if not elements:
+                ctk_cli.module.logger.warning("No <element>s found within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+        else:
+            self.elements = None
+            if elements:
+                ctk_cli.module.logger.warning("Ignoring <element>s within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+
+        return self
+
+
 @classmethod  # noqa
 def _ctkCliParse(cls, elementTree):  # noqa
-    assert ctk_cli.module._tag(elementTree) in cls.TYPES, "%s not in CLIParameter.TYPES" % ctk_cli.module._tag(elementTree)  # noqa
-
     self = cls()
-    self.typ = ctk_cli.module._tag(elementTree)
 
-    if self.typ in ('point', 'region'):
-        self._pythonType = float
-    else:
-        elementType = self.typ
-        if elementType.endswith('-vector'):
-            elementType = elementType[:-7]
-        elif elementType.endswith('-enumeration'):
-            elementType = elementType[:-12]
-        self._pythonType = self.PYTHON_TYPE_MAPPING.get(elementType, str)
+    childNodes = ctk_cli.module._parseElements(self, elementTree, 'parameters')
 
-    self.hidden = ctk_cli.module._parseBool(elementTree.get('hidden', 'false'))
+    self.advanced = ctk_cli.module._parseBool(elementTree.get('advanced', 'false'))
 
-    self.constraints = None
-    self.multiple = None
-    self.elements = None
-    self.coordinateSystem = None
-    self.fileExtensions = None
-    self.reference = None
-    self.subtype = None
-
-    for key, value in elementTree.items():
-        if key == 'multiple':
-            self.multiple = ctk_cli.module._parseBool(value)
-        # Added region (slicer_cli_web)
-        elif key == 'coordinateSystem' and self.typ in ('point', 'pointfile', 'region'):
-            self.coordinateSystem = value
-        elif key == 'fileExtensions':
-            self.fileExtensions = [ext.strip() for ext in value.split(',')]
-        # Added file (slicer_cli_web)
-        elif key == 'reference' and self.typ in ('image', 'file', 'transform', 'geometry', 'table'):  # noqa
-            self.reference = value
-            # Suppressed warning (slicer_cli_web)
-            # ctk_cli.module.logger.warning("'reference' attribute of %r is not part of the spec yet (CTK issue #623)" % (ctk_cli.module._tag(elementTree), ))  # noqa
-        elif key == 'type':
-            self.subtype = value
-        elif key != 'hidden':
-            ctk_cli.module.logger.warning('attribute of %r ignored: %s=%r' % (ctk_cli.module._tag(elementTree), key, value))  # noqa
-
-    elements = []
-
-    childNodes = ctk_cli.module._parseElements(self, elementTree)
-    for n in childNodes:
-        if ctk_cli.module._tag(n) == 'constraints':
-            self.constraints = ctk_cli.module.CLIConstraints.parse(n)
-        elif ctk_cli.module._tag(n) == 'element':
-            if not n.text:
-                ctk_cli.module.logger.warning("Ignoring empty <element> within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
-            else:
-                elements.append(n.text)
-        else:
-            ctk_cli.module.logger.warning("Element %r within %r not parsed" % (ctk_cli.module._tag(n), ctk_cli.module._tag(elementTree)))  # noqa
-
-    # Added channel and external type checks (slicer_cli_web)
-    if (not self.flag and not self.longflag and self.index is None and
-            (self.channel != 'output' or self.isExternalType())):
-        ctk_cli.module.logger.warning("Parameter %s cannot be passed (missing one of flag, longflag, or index)!" % (  # noqa
-            self.identifier(), ))
-
-    if self.flag and not self.flag.startswith('-'):
-        self.flag = '-' + self.flag
-    if self.longflag and not self.longflag.startswith('-'):
-        self.longflag = '--' + self.longflag
-
-    if self.index is not None:
-        self.index = int(self.index)
-
-    if self.default:
-        try:
-            self.default = self.parseValue(self.default)
-        except ValueError as e:
-            ctk_cli.module.logger.warning('Could not parse default value of <%s> (%s): %s' % (
-                ctk_cli.module._tag(elementTree), self.name, e))
-
-    if self.typ.endswith('-enumeration'):
-        try:
-            self.elements = list(map(self.parseValue, elements))
-        except ValueError as e:
-            ctk_cli.module.logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (  # noqa
-                ctk_cli.module._tag(elementTree), self.name, e))
-        if not elements:
-            ctk_cli.module.logger.warning("No <element>s found within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
-    else:
-        self.elements = None
-        if elements:
-            ctk_cli.module.logger.warning("Ignoring <element>s within <%s>" % (ctk_cli.module._tag(elementTree), ))  # noqa
+    for pnode in childNodes:
+        self.append(CLIParameter.parse(pnode))
 
     return self
 
 
-ctk_cli.module.CLIParameter.parse = _ctkCliParse
+ctk_cli.module.CLIParameters.parse = _ctkCliParse
 
 CLIModule = ctk_cli.CLIModule
 

--- a/slicer_cli_web/models/json_to_xml.py
+++ b/slicer_cli_web/models/json_to_xml.py
@@ -29,7 +29,8 @@ def _convert_param(parent, param):
 
     _copy(p, param, 'label', 'description', 'name', 'index', 'channel')
 
-    _copy_attr(p, param, 'coordinateSystem', 'fileExtensions',
+    _copy_attr(p, param,
+               'coordinateSystem', 'fileExtensions', 'defaultPathMatch', 'defaultNameMatch',
                image_type='type', table_type='type', geometry_type='type',
                transform_type='type')
 

--- a/slicer_cli_web/models/schema.json
+++ b/slicer_cli_web/models/schema.json
@@ -39,6 +39,14 @@
       "pattern": "(?:(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)(?:,\\s*(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)*",
       "description": "fileExtensions can contain a list of comma separated file extensions for optional use by the GUI."
     },
+    "defaultPathMatch": {
+      "type": "string",
+      "description": "A regular expression that can be used to match a file, item, or folder total path to prepopulate a default value.  When used with Girder, this matches the resource path."
+    },
+    "defaultNameMatch": {
+      "type": "string",
+      "description": "A regular expression that can be used to match a file, item, or folder name to prepopulate a default value.  When used with Girder, this matches the resource name."
+    },
     "reference": {
       "oneOf": [
         {
@@ -551,6 +559,12 @@
                     "fileExtensions": {
                       "$ref": "#/definitions/fileExtensions"
                     },
+                    "defaultPathMatch": {
+                      "$ref": "#/definitions/defaultPathMatch"
+                    },
+                    "defaultNameMatch": {
+                      "$ref": "#/definitions/defaultNameMatch"
+                    },
                     "reference": {
                       "$ref": "#/definitions/reference"
                     }
@@ -596,6 +610,12 @@
                     },
                     "fileExtensions": {
                       "$ref": "#/definitions/fileExtensions"
+                    },
+                    "defaultPathMatch": {
+                      "$ref": "#/definitions/defaultPathMatch"
+                    },
+                    "defaultNameMatch": {
+                      "$ref": "#/definitions/defaultNameMatch"
                     }
                   }
                 },
@@ -616,6 +636,12 @@
                     },
                     "fileExtensions": {
                       "$ref": "#/definitions/fileExtensions"
+                    },
+                    "defaultPathMatch": {
+                      "$ref": "#/definitions/defaultPathMatch"
+                    },
+                    "defaultNameMatch": {
+                      "$ref": "#/definitions/defaultNameMatch"
                     },
                     "reference": {
                       "$ref": "#/definitions/reference"
@@ -690,6 +716,12 @@
                       "pattern": "(?:(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)(?:,\\s*(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)*",
                       "default": ".tsv|.csv|.txt|.ctbl"
                     },
+                    "defaultPathMatch": {
+                      "$ref": "#/definitions/fileExtensions"
+                    },
+                    "defaultNameMatch": {
+                      "$ref": "#/definitions/fileExtensions"
+                    },
                     "reference": {
                       "$ref": "#/definitions/reference"
                     }
@@ -724,6 +756,12 @@
                       "description": "fileExtensions can contain a list of comma separated file extensions for optional use by the GUI.",
                       "pattern": "(?:(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)(?:,\\s*(?:\\.[^,\\s]|[^,\\.\\s\\*])[^,\\s]*)*",
                       "default": ".tfm,.h5,.hdf5,.mat,.txt"
+                    },
+                    "defaultPathMatch": {
+                      "$ref": "#/definitions/fileExtensions"
+                    },
+                    "defaultNameMatch": {
+                      "$ref": "#/definitions/fileExtensions"
                     },
                     "reference": {
                       "$ref": "#/definitions/reference"

--- a/slicer_cli_web/web_client/parser/param.js
+++ b/slicer_cli_web/web_client/parser/param.js
@@ -36,6 +36,9 @@ export default function param(paramTag, opts = {}) {
             [id]: type
         });
         return null;
+    } else if (channel === 'input' && ['image', 'file', 'item', 'directory'].includes(type)) {
+        extra.defaultNameMatch = $param.attr('defaultNameMatch');
+        extra.defaultPathMatch = $param.attr('defaultPathMatch');
     }
 
     if (!type) {

--- a/slicer_cli_web/web_client/templates/fileWidget.pug
+++ b/slicer_cli_web/web_client/templates/fileWidget.pug
@@ -4,7 +4,14 @@ block input
   .input-group
     if value && value.name
       - value = value.name();
-    +input(title, type, id, value)(placeholder='Choose a file...', readonly=true)
+    - var placeholder = 'Choose a file...'
+    if type === 'item'
+      - placeholder = 'Choose an item...'
+    if type === 'image'
+      - placeholder = 'Choose an image...'
+    if type === 'directory'
+      - placeholder = 'Choose a folder...'
+    +input(title, type, id, value)(placeholder=placeholder, readonly=true)
     span.input-group-btn
       button.btn.btn-default.s-select-file-button(type='button')
         i.icon-folder-open

--- a/slicer_cli_web/web_client/views/ConfigView.js
+++ b/slicer_cli_web/web_client/views/ConfigView.js
@@ -50,6 +50,9 @@ const ConfigView = View.extend({
                     isValid.resolve();
                 }
                 return isValid.promise();
+            },
+            rootSelectorSettings: {
+                pageLimit: 1000
             }
         });
         this.listenTo(this._browserWidgetView, 'g:saved', (val) => {

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -57,7 +57,6 @@ const ControlWidget = View.extend({
         if (channel === 'input') {
             if (model.get('defaultNameMatch') || model.get('defaultPathMatch')) {
                 this._getDefaultInputResource(model).then((resource) => {
-                    console.log('H', resource, model);
                     if (!resource) {
                         return null;
                     }

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -7,6 +7,9 @@ import events from '@girder/core/events';
 import { getCurrentUser } from '@girder/core/auth';
 import FolderCollection from '@girder/core/collections/FolderCollection';
 import ItemModel from '@girder/core/models/ItemModel';
+import FileModel from '@girder/core/models/FileModel';
+import FolderModel from '@girder/core/models/FolderModel';
+import { restRequest } from '@girder/core/rest';
 
 import ItemSelectorWidget from './ItemSelectorWidget';
 
@@ -46,16 +49,26 @@ const ControlWidget = View.extend({
     },
 
     _initModel(settings) {
-        if (!settings.setDefaultOutput) {
-            return;
-        }
-
         const prefix = settings.setDefaultOutput;
         const model = this.model;
         const type = model.get('type');
         const channel = model.get('channel');
         const required = model.get('required');
-        if (!required || channel !== 'output' || !['new-file', 'file', 'item', 'directory'].includes(type)) {
+        if (channel === 'input') {
+            if (model.get('defaultNameMatch') || model.get('defaultPathMatch')) {
+                this._getDefaultInputResource(model).then((resource) => {
+                    console.log('H', resource, model);
+                    if (!resource) {
+                        return null;
+                    }
+                    this.model.set({
+                        value: resource
+                    });
+                    return null;
+                });
+            }
+        }
+        if (!prefix || !required || channel !== 'output' || !['new-file', 'file', 'item', 'directory'].includes(type)) {
             return;
         }
         this._getDefaultOutputFolder().then((folder) => {
@@ -239,7 +252,10 @@ const ControlWidget = View.extend({
             el: $('#g-dialog-container'),
             parentView: this,
             model: this.model,
-            rootPath: this._rootPath
+            rootPath: this._rootPath,
+            rootSelectorSettings: {
+                pageLimit: 1000
+            }
         });
         modal.once('g:saved', () => {
             modal.$el.modal('hide');
@@ -270,6 +286,22 @@ const ControlWidget = View.extend({
             });
         }).then(() => {
             return userFolders.isEmpty() ? null : userFolders.at(0);
+        });
+    },
+
+    _getDefaultInputResource(model) {
+        var type = {image: 'item', item: 'item', file: 'file', directory: 'folder'}[model.get('type')];
+        return restRequest({
+            url: 'slicer_cli_web/path_match',
+            data: {
+                type: type,
+                name: model.get('defaultNameMatch'),
+                path: model.get('defaultPathMatch')
+            },
+            error: null
+        }).then((resource) => {
+            var ModelType = {image: ItemModel, item: ItemModel, file: FileModel, directory: FolderModel}[model.get('type')];
+            return new ModelType(resource);
         });
     },
 

--- a/slicer_cli_web/web_client/views/ItemView.js
+++ b/slicer_cli_web/web_client/views/ItemView.js
@@ -47,6 +47,7 @@ const SlicerUI = View.extend({
         this.$el.html(slicerUI({
             panels: this.panels
         }));
+        console.log('--', this.taskModel, this.taskModel.get('name')); // DWM::
         this.panels.forEach((panel) => {
             this._panelViews[panel.id] = new ControlsPanel({
                 controlWidget: {

--- a/slicer_cli_web/web_client/views/ItemView.js
+++ b/slicer_cli_web/web_client/views/ItemView.js
@@ -47,7 +47,6 @@ const SlicerUI = View.extend({
         this.$el.html(slicerUI({
             panels: this.panels
         }));
-        console.log('--', this.taskModel, this.taskModel.get('name')); // DWM::
         this.panels.forEach((panel) => {
             this._panelViews[panel.id] = new ControlsPanel({
                 controlWidget: {

--- a/small-docker/Example1/Example1.json
+++ b/small-docker/Example1/Example1.json
@@ -5,6 +5,7 @@
   "description": "Shows one of each type of parameter that slicer_cli_web can handle.",
   "version": "0.1.0.$Revision$(alpha)",
   "documentation-url": "http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/ExecutionModelTour",
+  "license": "",
   "contributor": "Daniel Blezek (GE), Bill Lorensen (GE)",
   "acknowledgements": "This work is part of the National Alliance for Medical Image Computing (NAMIC), funded by the National Institutes of Health through the NIH Roadmap for Medical Research, Grant U54 EB005149.  It has been modified for slicer_cli_web.",
   "parameter_groups": [
@@ -141,6 +142,8 @@
         {
           "type": "file",
           "fileExtensions": ".png,.jpg,.jpeg,.bmp,.tif,.tiff,.gipl,.dcm,.dicom,.nhdr,.nrrd,.mhd,.mha,.mask,.hdr,.nii,.nii.gz,.hdr.gz,.pic,.lsm,.spr,.vtk,.vtkp,.vtki,.stl,.csv,.txt,.xml,.html",
+          "defaultNameMatch": "\\.png$",
+          "defaultPathMatch": "^\\/user\\/.*\\/[Ii]mages\\/.*\\.png$",
           "name": "file1",
           "longflag": "file1",
           "description": "An input file",

--- a/small-docker/Example1/Example1.xml
+++ b/small-docker/Example1/Example1.xml
@@ -107,7 +107,7 @@
   <parameters>
     <label>File, Directory and Image Parameters</label>
     <description><![CDATA[Parameters that describe files and direcories.]]></description>
-    <file fileExtensions=".png,.jpg,.jpeg,.bmp,.tif,.tiff,.gipl,.dcm,.dicom,.nhdr,.nrrd,.mhd,.mha,.mask,.hdr,.nii,.nii.gz,.hdr.gz,.pic,.lsm,.spr,.vtk,.vtkp,.vtki,.stl,.csv,.txt,.xml,.html">
+    <file fileExtensions=".png,.jpg,.jpeg,.bmp,.tif,.tiff,.gipl,.dcm,.dicom,.nhdr,.nrrd,.mhd,.mha,.mask,.hdr,.nii,.nii.gz,.hdr.gz,.pic,.lsm,.spr,.vtk,.vtkp,.vtki,.stl,.csv,.txt,.xml,.html" defaultNameMatch="\.png$" defaultPathMatch="^\/user\/.*\/[Ii]mages\/.*\.png$">
       <name>file1</name>
       <longflag>file1</longflag>
       <description><![CDATA[An input file]]></description>

--- a/small-docker/Example1/Example1.yaml
+++ b/small-docker/Example1/Example1.yaml
@@ -3,6 +3,7 @@ title: Execution Model Tour
 description: Shows one of each type of parameter that slicer_cli_web can handle.
 version: 0.1.0.$Revision$(alpha)
 documentation-url: http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/ExecutionModelTour
+license: ''
 contributor: Daniel Blezek (GE), Bill Lorensen (GE)
 acknowledgements: This work is part of the National Alliance for Medical Image Computing
   (NAMIC), funded by the National Institutes of Health through the NIH Roadmap for
@@ -102,6 +103,8 @@ parameter_groups:
   parameters:
   - type: file
     fileExtensions: .png,.jpg,.jpeg,.bmp,.tif,.tiff,.gipl,.dcm,.dicom,.nhdr,.nrrd,.mhd,.mha,.mask,.hdr,.nii,.nii.gz,.hdr.gz,.pic,.lsm,.spr,.vtk,.vtkp,.vtki,.stl,.csv,.txt,.xml,.html
+    defaultNameMatch: \.png$
+    defaultPathMatch: ^\/user\/.*\/[Ii]mages\/.*\.png$
     name: file1
     longflag: file1
     description: An input file

--- a/tests/test_rest_slicer_cli.py
+++ b/tests/test_rest_slicer_cli.py
@@ -1,20 +1,22 @@
+import json
 import os
 import pytest
-import json
+
+from girder.api import rest
+from girder.models.item import Item
+
+from slicer_cli_web import docker_resource
+from slicer_cli_web import rest_slicer_cli
+from slicer_cli_web.models import CLIItem
 
 
 @pytest.mark.plugin('slicer_cli_web')
-def test_genHandlerToRunDockerCLI(admin, folder, file, adminToken, mocker):
-    mocker.patch('girder.api.rest.getCurrentToken').return_value = adminToken
-    mocker.patch('girder.api.rest.getApiUrl').return_value = '/api/v1'
-
-    from girder.api import rest
-    from slicer_cli_web import docker_resource
-    from slicer_cli_web import rest_slicer_cli
-    from slicer_cli_web.models import CLIItem
-    from girder.models.item import Item
-
+def test_genHandlerToRunDockerCLI(server, admin, folder, file):
+    # Make a request to allow ther eto be some lingering context to handle the
+    # testing outside of a request for the actual handler.
+    server.request('/system/version')
     rest.setCurrentUser(admin)
+
     xmlpath = os.path.join(os.path.dirname(__file__), 'data', 'ExampleSpec.xml')
 
     girderCLIItem = Item().createItem('data', admin, folder)

--- a/tests/test_rest_slicer_cli.py
+++ b/tests/test_rest_slicer_cli.py
@@ -1,8 +1,11 @@
 import json
 import os
 import pytest
+from pytest_girder.assertions import assertStatusOk, assertStatus
 
 from girder.api import rest
+from girder.models.collection import Collection
+from girder.models.folder import Folder
 from girder.models.item import Item
 
 from slicer_cli_web import docker_resource
@@ -51,3 +54,68 @@ def test_genHandlerToRunDockerCLI(server, admin, folder, file):
     assert kwargs['pull_image'] == 'if-not-present'
     container_args = kwargs['container_args']
     assert container_args[0] == 'data'
+
+
+@pytest.mark.plugin('slicer_cli_web')
+def test_get_matching_resource(server, admin):
+    # Make some resources
+    publicFolder = Folder().find({'parentId': admin['_id'], 'name': 'Public'})[0]
+    privateFolder = Folder().find({'parentId': admin['_id'], 'name': 'Private'})[0]
+    # Create some resources to use in the tests; this was mostly copied from a
+    # test in another repo and has more items and folders than needed
+    collection = Collection().createCollection(
+        'collection A', admin)
+    colFolderA = Folder().createFolder(
+        collection, 'folder A', parentType='collection',
+        creator=admin)
+    colFolderB = Folder().createFolder(
+        collection, 'folder B', parentType='collection',
+        creator=admin)
+    colFolderC = Folder().createFolder(
+        colFolderA, 'folder C', creator=admin)
+    Item().createItem('item A1', admin, colFolderA)
+    Item().createItem('item B1', admin, colFolderB)
+    Item().createItem('item B2', admin, colFolderB)
+    Item().createItem('item C1', admin, colFolderC)
+    Item().createItem('item C2', admin, colFolderC)
+    Item().createItem('item C3', admin, colFolderC)
+    Item().createItem('item Public 1', admin, publicFolder)
+    Item().createItem('item Private 1', admin, privateFolder)
+    folderD = Folder().createFolder(publicFolder, 'folder D', creator=admin)
+    Item().createItem('item D1', admin, folderD)
+    Item().createItem('item D2', admin, folderD)
+    # Now test
+    resp = server.request('/slicer_cli_web/path_match', params={
+        'type': 'folder',
+        'name': '^fold.*D',
+    }, user=admin)
+    assertStatusOk(resp)
+    assert resp.json['name'] == 'folder D'
+
+    resp = server.request('/slicer_cli_web/path_match', params={
+        'type': 'item',
+        'name': '^item',
+        'path': '^/collection/.*/folder.*/folder',
+    }, user=admin)
+    assertStatusOk(resp)
+    assert resp.json['name'] == 'item C3'
+
+    resp = server.request('/slicer_cli_web/path_match', params={
+        'type': 'item',
+        'name': '^item .* 1',
+    }, user=admin)
+    assertStatusOk(resp)
+    assert resp.json['name'] == 'item Private 1'
+
+    resp = server.request('/slicer_cli_web/path_match', params={
+        'type': 'item',
+        'name': '^item .* 1',
+    })
+    assertStatusOk(resp)
+    assert resp.json['name'] == 'item Public 1'
+
+    resp = server.request('/slicer_cli_web/path_match', params={
+        'type': 'item',
+        'name': 'nosuchitem',
+    })
+    assertStatus(resp, 400)

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,8 @@ whitelist_externals =
   rm
 commands =
   rm -rf build/test/coverage/web_temp
-  mkdir -p build/test-reports
-  rm -rf build/test-reports
   girder build --dev
-  pytest --cov {envsitepackagesdir}/slicer_cli_web --junitxml=build/test-reports/junit.xml {posargs}
-  # npx nyc report --temp-dir .tox/coverage --report-dir .tox/coverage --reporter cobertura --reporter text-summary
-  # When client tests are enabled, add the temp-dir.
+  pytest --cov {envsitepackagesdir}/slicer_cli_web {posargs}
   npx nyc report --temp-dir build/test/coverage/web_temp --report-dir .tox/coverage --reporter cobertura --reporter text-summary
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,22 @@
 [tox]
 envlist =
-  py{27,36,37}
+  py{27,36,37,38,39}
   flake8
   lintclient
 [testenv]
-passenv = *
+passenv =
+  DOCKER_*
+  PYTEST_*
 deps =
   coverage
   mock
-  pytest
-  pytest-cov
+  pytest>=3.6
+  pytest-cov>=2.6
+  pytest-girder>=3.0.4; python_version >= '3.6'
+  pytest-girder>=3.0.4,<3.1; python_version < '3.6'
   pytest-mock
-  pytest-girder>=3.0.2
   pytest-xdist
-install_command = pip install --upgrade --upgrade-strategy eager --find-links https://manthey.github.io/large_image_wheels {opts} .[girder,worker] {packages}
+install_command = pip install --upgrade --find-links https://manthey.github.io/large_image_wheels {opts} .[girder,worker] {packages}
 whitelist_externals =
   mkdir
   npx


### PR DESCRIPTION
On some input types (`file`, `item`, `image`, `folder`), you can specify a `defaultNameMatch` and `defaultPathMatch` attributes (much like `fileExtension` is used on some outputs).  These are hints to the UI to find a matching file.  For the Girder UI, this is done on the resource path, with the name match applying to the specific Girder resource and the path match applying to the full resource path (e.g., /user/<user name>/<folder name>.../<resource name>).

These are regex; if you need to match the whole string, add begin and end anchors (e.g., '\.png$' will match any .png, '^a.*\.png$' will match a png that starts with 'a').