### PR TITLE
Fix general return parameters and directories.

### DIFF
--- a/slicer_cli_web/web_client/collections/WidgetCollection.js
+++ b/slicer_cli_web/web_client/collections/WidgetCollection.js
@@ -18,6 +18,7 @@ const WidgetCollection = Backbone.Collection.extend({
                 case 'file':
                 case 'item':
                 case 'image':
+                case 'directory':
                     params[m.id] = m.value().id;
                     break;
                 case 'new-file':

--- a/slicer_cli_web/web_client/views/ItemView.js
+++ b/slicer_cli_web/web_client/views/ItemView.js
@@ -70,7 +70,7 @@ const SlicerUI = View.extend({
         const opts = {};
         this.spec = parse(xml, opts);
 
-        if (opts.outputs) {
+        if (opts.output) {
             this._addParamFileOutput();
         }
 


### PR DESCRIPTION
Fix a bug where the item view wouldn't show a general return parameter file output option.

Fix a bug where selecting an input directory would not pass the proper value.