### PR TITLE
Add support for passing GC info to a docker job.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ The XML must conform to the `Slicer Execution Schema <https://www.slicer.org/w/i
 
 - Some input types (``image``, ``file``, ``item``, ``directory``) can have ``defaultNameMatch`` and ``defaultPathMatch`` properties.  These are regular expressions designed to give a UI a value to match to prepopulate default values from files or paths that match the regex.  ``defaultNameMatch`` is intended to match the final path element, whereas ``defaultPathMatch`` is used on the entire path as a combined string.
 
+- There are some special string parameters that, if unspecified or blank, are autopopulated.  String parameters with the names of ``girderApiUrl`` and ``girderApiKey`` are populated with the appropriate url and token so that a running job could use girder_client to communicate with Girder.
+
 
 .. |build-status| image:: https://circleci.com/gh/girder/slicer_cli_web.svg?style=svg
     :target: https://circleci.com/gh/girder/slicer_cli_web

--- a/slicer_cli_web/cli_utils.py
+++ b/slicer_cli_web/cli_utils.py
@@ -77,3 +77,7 @@ def get_cli_parameters(clim):
 
 def is_on_girder(param):
     return param.typ in SLICER_TYPE_TO_GIRDER_MODEL_MAP
+
+
+def is_girder_api(param):
+    return param.name in {'girderApiUrl', 'girderApiKey'}

--- a/slicer_cli_web/girder_worker_plugin/direct_docker_run.py
+++ b/slicer_cli_web/girder_worker_plugin/direct_docker_run.py
@@ -6,6 +6,7 @@ from girder_worker.docker.transforms import BindMountVolume
 from girder_worker.docker.transforms.girder import GirderFileIdToVolume
 from girder_worker.docker.tasks import _docker_run, DockerTask
 from girder_worker_utils import _walk_obj
+from girder_worker_utils.transforms.girder_io import GirderClientTransform
 
 
 def _get_basename(filename, direct_path):
@@ -41,6 +42,16 @@ class DirectGirderFileIdToVolume(GirderFileIdToVolume):
         if self._direct_container_path:
             return self._direct_container_path
         return super(DirectGirderFileIdToVolume, self).transform(**kwargs)
+
+
+class GirderApiUrl(GirderClientTransform):
+    def transform(self, **kwargs):
+        return self.gc.urlBase
+
+
+class GirderApiKey(GirderClientTransform):
+    def transform(self, **kwargs):
+        return self.gc.token
 
 
 def _resolve_direct_file_paths(args, kwargs):

--- a/slicer_cli_web/web_client/models/WidgetModel.js
+++ b/slicer_cli_web/web_client/models/WidgetModel.js
@@ -185,7 +185,7 @@ const WidgetModel = Backbone.Model.extend({
         // make sure value is approximately an integer number
         // of "steps" larger than "min"
         min = min || 0;
-        const mod = (value - min) / step;
+        const mod = (value - min) / (step || 1);
         if (step > 0 && Math.abs(Math.round(mod) - mod) > eps) {
             return 'Value does not satisfy step "' + step + '"';
         }
@@ -214,7 +214,7 @@ const WidgetModel = Backbone.Model.extend({
         // make sure value is approximately an integer number
         // of "steps" larger than "min"
         min = min || 0;
-        if ((value - min) % step) {
+        if (step > 0 && ((value - min) % (step || 1))) {
             return `Value does not satisfy step "${step}"`;
         }
     },

--- a/small-docker/Dockerfile
+++ b/small-docker/Dockerfile
@@ -14,8 +14,8 @@ RUN chmod a+x /usr/local/bin/groupadd
 RUN touch /usr/local/bin/useradd
 RUN chmod a+x /usr/local/bin/useradd
 
-# We need ctk-cli to parse inputs
-RUN pip install ctk-cli
+# We need either ctk-cli or our equivalent to parse inputs
+RUN pip install --pre girder-slicer-cli-web
 COPY . $PWD
 
 ENTRYPOINT ["python", "./cli_list.py"]

--- a/small-docker/Example1/Example1.json
+++ b/small-docker/Example1/Example1.json
@@ -107,6 +107,29 @@
       ]
     },
     {
+      "advanced": true,
+      "label": "Girder API URL and Key",
+      "description": "A Girder API URL and token for Girder client",
+      "parameters": [
+        {
+          "type": "string",
+          "name": "girderApiUrl",
+          "longflag": "api-url",
+          "label": "Girder API URL",
+          "description": "A Girder API URL (e.g., https://girder.example.com:443/api/v1)",
+          "default": ""
+        },
+        {
+          "type": "string",
+          "name": "girderApiKey",
+          "longflag": "api-key",
+          "label": "Girder API Key",
+          "description": "A Girder token",
+          "default": ""
+        }
+      ]
+    },
+    {
       "label": "Boolean Parameters",
       "description": "Variations on boolean parameters",
       "parameters": [
@@ -247,7 +270,7 @@
         {
           "type": "string",
           "name": "astringreturn",
-          "label": "A string point return value",
+          "label": "A string return value",
           "channel": "output",
           "default": "Hello",
           "description": "An example of a string return type"

--- a/small-docker/Example1/Example1.py
+++ b/small-docker/Example1/Example1.py
@@ -1,9 +1,18 @@
+import pprint
+
+from slicer_cli_web import ctk_cli_adjustment  # noqa - imported for side effects
 from ctk_cli import CLIArgumentParser
 
 
 def main(args):
     print('>> parsed arguments')
     print('%r' % args)
+    pprint.pprint(vars(args), width=1000)
+    with open(args.returnParameterFile, 'w') as f:
+        f.write('>> parsed arguments\n')
+        f.write('%r\n' % args)
+    with open(args.arg1, 'w') as f:
+        f.write('example\n')
 
 
 if __name__ == '__main__':

--- a/small-docker/Example1/Example1.xml
+++ b/small-docker/Example1/Example1.xml
@@ -80,6 +80,24 @@
       <element>Will</element>
     </string-enumeration>
   </parameters>
+  <parameters advanced="true">
+    <label>Girder API URL and Key</label>
+    <description>A Girder API URL and token for Girder client</description>
+    <string>
+      <name>girderApiUrl</name>
+      <longflag>api-url</longflag>
+      <label>Girder API URL</label>
+      <description>A Girder API URL (e.g., https://girder.example.com:443/api/v1)</description>
+      <default></default>
+    </string>
+    <string>
+      <name>girderApiKey</name>
+      <longflag>api-key</longflag>
+      <label>Girder API Key</label>
+      <description>A Girder token</description>
+      <default></default>
+    </string>
+  </parameters>
   <parameters>
     <label>Boolean Parameters</label>
     <description><![CDATA[Variations on boolean parameters]]></description>
@@ -194,7 +212,7 @@
     </double>
     <string>
       <name>astringreturn</name>
-      <label>A string point return value</label>
+      <label>A string return value</label>
       <channel>output</channel>
       <default>Hello</default>
       <description><![CDATA[An example of a string return type]]></description>

--- a/small-docker/Example1/Example1.yaml
+++ b/small-docker/Example1/Example1.yaml
@@ -78,6 +78,22 @@ parameter_groups:
     - Ross
     - Steve
     - Will
+- advanced: true
+  description: A Girder API URL and token for Girder client
+  label: Girder API URL and Key
+  parameters:
+  - type: string
+    name: girderApiUrl
+    longflag: api-url
+    label: Girder API URL
+    description: A Girder API URL (e.g., https://girder.example.com:443/api/v1)
+    default: ''
+  - type: string
+    name: girderApiKey
+    longflag: api-key
+    label: Girder API Key
+    description: A Girder token
+    default: ''
 - description: Variations on boolean parameters
   label: Boolean Parameters
   parameters:
@@ -181,7 +197,7 @@ parameter_groups:
     description: An example of a double return type
   - type: string
     name: astringreturn
-    label: A string point return value
+    label: A string return value
     channel: output
     default: Hello
     description: An example of a string return type

--- a/small-docker/Example3/Example3.json
+++ b/small-docker/Example3/Example3.json
@@ -20,7 +20,8 @@
           "channel": "input",
           "constraints": {
             "minimum": 0.0,
-            "maximum": 1.0
+            "maximum": 1.0,
+            "step": 0.0
           }
         }
       ]

--- a/small-docker/Example3/Example3.xml
+++ b/small-docker/Example3/Example3.xml
@@ -18,6 +18,7 @@
       <constraints>
         <minimum>0</minimum>
         <maximum>1</maximum>
+        <step>0</step>
       </constraints>
     </float>
   </parameters>

--- a/small-docker/Example3/Example3.yaml
+++ b/small-docker/Example3/Example3.yaml
@@ -18,3 +18,4 @@ parameter_groups:
     constraints:
       minimum: 0.0
       maximum: 1.0
+      step: 0.0


### PR DESCRIPTION
Empty string parameters named `girderApiUrl` and `girderApiKey` will be populated with the current Girder api-url and job token that can be used with girder client inside a running docker container.