### PR TITLE
Client/default selected resource

### DIFF
--- a/slicer_cli_web/web_client/templates/fileWidget.pug
+++ b/slicer_cli_web/web_client/templates/fileWidget.pug
@@ -3,7 +3,7 @@ extends ./widget.pug
 block input
   .input-group
     if value && value.name && type === 'multi' && folderName !== undefined
-      - value = `${folderName}/RegEx(${value.name()})`;
+      - value = `${folderName}/RegEx(${value.name() || '.*'})`;
     else if value && value.name
       - value = value.name();
     - var placeholder = 'Choose a file...'

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -9,6 +9,9 @@ import FolderCollection from '@girder/core/collections/FolderCollection';
 import ItemModel from '@girder/core/models/ItemModel';
 import FileModel from '@girder/core/models/FileModel';
 import FolderModel from '@girder/core/models/FolderModel';
+import UserModel from '@girder/core/models/FolderModel';
+import CollectionModel from '@girder/core/models/CollectionModel';
+
 import { restRequest } from '@girder/core/rest';
 
 import ItemSelectorWidget from './ItemSelectorWidget';
@@ -269,7 +272,8 @@ const ControlWidget = View.extend({
                 type: t,
             });
         }
-        const modal = new ItemSelectorWidget({
+
+        const itemSelectorSettings = {
             el: $('#g-dialog-container'),
             parentView: this,
             model: this.model,
@@ -277,7 +281,75 @@ const ControlWidget = View.extend({
             rootSelectorSettings: {
                 pageLimit: 1000
             }
-        });
+        };
+        if (this.model.get('value')){       
+            this.getRoot(this.model.get('value'), itemSelectorSettings);
+        } else {
+            this.completeInitialization(itemSelectorSettings);
+        }
+
+    },
+    /**
+     * Used to collect the root of the resource passed to the itemSelectorWidget to enable the defaultSelectedResource
+     * The value is not an actual model so we need to fetch the model from the itemId, folderID, or if it is the item, the actual item
+     * @param {*} resource - value object for model containing either itemId, folderId, or a standard model
+     * @param {*} settings - ItemSelectorWidget settings extended from BrowserWidget
+     */
+    getRoot(resource, settings) {
+
+        const modelTypes = {
+            item: ItemModel,
+            folder: FolderModel,
+            collection: CollectionModel,
+            user: UserModel
+        };
+        let modelType = 'folder'; // folder type by default, other types if necessary
+        let modelId = null;
+        // If it is an item it will have a folderId associated with it as a parent item
+        if (resource.get('itemId')) {
+            modelId = resource.get('itemId');
+            modelType = 'item';
+        } else if (resource.get('folderId')) {
+            modelId = resource.get('folderId');
+        } else if (resource.get('parentCollection')) {
+            // Case for providing a folder as the defaultSelectedResource but want the user to select an item
+            // folder parent is either 'user' | 'folder' | 'collection', most likely folder though
+            modelType = resource.get('parentCollection');
+            modelId = resource.get('parentId');
+        }
+        // We need to fetch the itemID to get the model stuff
+        if (modelType === 'item') {
+            const itemModel = new modelTypes[modelType]();
+            itemModel.set({
+                _id: modelId
+            }).on('g:fetched', function () {
+                settings.defaultSelectedResource = itemModel;
+                settings.highlightItem = true;
+                settings.selectItem = true;
+                this.getRoot(itemModel, settings)
+            }, this).on('g:error', function () {
+                settings.root = null;
+                this.completeInitialization(settings)
+            }, this).fetch();
+        }
+        else if (modelTypes[modelType] && modelId) {
+            const parentModel = new modelTypes[modelType]();
+            parentModel.set({
+                _id: modelId
+            }).on('g:fetched', function () {
+                settings.root = parentModel;
+                settings.rootSelectorSettings.selectByResource = parentModel;
+                this.completeInitialization(settings);
+            }, this).on('g:error', function () {
+                settings.root = null;
+                this.completeInitialization(settings)
+            }, this).fetch();
+        } else {
+            this.completeInitialization(settings);
+        }
+    },
+    completeInitialization(settings) {
+        const modal = new ItemSelectorWidget(settings);
         modal.once('g:saved', () => {
             modal.$el.modal('hide');
         }).render();
@@ -291,7 +363,8 @@ const ControlWidget = View.extend({
                 defaultType: t,
             });
         }
-        const modal = new ItemSelectorWidget({
+
+        const itemSelectorSettings = {
             el: $('#g-dialog-container'),
             parentView: this,
             model: this.model,
@@ -299,10 +372,12 @@ const ControlWidget = View.extend({
             rootSelectorSettings: {
                 pageLimit: 1000
             }
-        });
-        modal.once('g:saved', () => {
-            modal.$el.modal('hide');
-        }).render();
+        };
+        if (this.model.get('value')){       
+            this.getRoot(this.model.get('value'), itemSelectorSettings);
+        } else {
+            this.completeInitialization(itemSelectorSettings);
+        }
     },
 
     _getDefaultOutputFolder() {

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -291,8 +291,8 @@ const ControlWidget = View.extend({
     /**
      * Used to collect the root of the resource passed to the itemSelectorWidget to enable the defaultSelectedResource
      * The value isn't always a valid model so we need to fetch the model from the itemId, folderID, or if it is the item, the actual item
-     * @param {*} resource - value object for model containing either itemId, folderId, or a standard model
-     * @param {*} settings - ItemSelectorWidget settings extended from BrowserWidget
+     * @param {*} resource value object for model containing either itemId, folderId, or a standard model
+     * @param {*} settings ItemSelectorWidget settings extended from BrowserWidget
      */
     getRoot(resource, settings) {
         const modelTypes = {

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -9,7 +9,7 @@ import FolderCollection from '@girder/core/collections/FolderCollection';
 import ItemModel from '@girder/core/models/ItemModel';
 import FileModel from '@girder/core/models/FileModel';
 import FolderModel from '@girder/core/models/FolderModel';
-import UserModel from '@girder/core/models/FolderModel';
+import UserModel from '@girder/core/models/UserModel';
 import CollectionModel from '@girder/core/models/CollectionModel';
 
 import { restRequest } from '@girder/core/rest';
@@ -257,7 +257,7 @@ const ControlWidget = View.extend({
         // If we converted to multi, convert it back to the older type
         // We reset the name if it was multi before
         if (this.model.get('type') === 'multi') {
-            if (this.model.get('value')){
+            if (this.model.get('value')) {
                 this.model.set({
                     value: new ItemModel({
                         folderId: this.model.get('value').get('folderId')
@@ -269,7 +269,7 @@ const ControlWidget = View.extend({
 
         if (t) {
             this.model.set({
-                type: t,
+                type: t
             });
         }
 
@@ -282,12 +282,11 @@ const ControlWidget = View.extend({
                 pageLimit: 1000
             }
         };
-        if (this.model.get('value')){       
+        if (this.model.get('value')) {
             this.getRoot(this.model.get('value'), itemSelectorSettings);
         } else {
             this.completeInitialization(itemSelectorSettings);
         }
-
     },
     /**
      * Used to collect the root of the resource passed to the itemSelectorWidget to enable the defaultSelectedResource
@@ -296,7 +295,6 @@ const ControlWidget = View.extend({
      * @param {*} settings - ItemSelectorWidget settings extended from BrowserWidget
      */
     getRoot(resource, settings) {
-
         const modelTypes = {
             item: ItemModel,
             folder: FolderModel,
@@ -326,13 +324,12 @@ const ControlWidget = View.extend({
                 settings.defaultSelectedResource = itemModel;
                 settings.highlightItem = true;
                 settings.selectItem = true;
-                this.getRoot(itemModel, settings)
+                this.getRoot(itemModel, settings);
             }, this).on('g:error', function () {
                 settings.root = null;
-                this.completeInitialization(settings)
+                this.completeInitialization(settings);
             }, this).fetch();
-        }
-        else if (modelTypes[modelType] && modelId) {
+        } else if (modelTypes[modelType] && modelId) {
             const parentModel = new modelTypes[modelType]();
             parentModel.set({
                 _id: modelId
@@ -342,7 +339,7 @@ const ControlWidget = View.extend({
                 this.completeInitialization(settings);
             }, this).on('g:error', function () {
                 settings.root = null;
-                this.completeInitialization(settings)
+                this.completeInitialization(settings);
             }, this).fetch();
         } else {
             this.completeInitialization(settings);
@@ -357,10 +354,10 @@ const ControlWidget = View.extend({
     _selectMultiFile() {
         // Store the current type in case it is opened again
         const t = this.model.get('type');
-        if (t !== 'multi'){
+        if (t !== 'multi') {
             this.model.set({
                 type: 'multi',
-                defaultType: t,
+                defaultType: t
             });
         }
 
@@ -373,7 +370,7 @@ const ControlWidget = View.extend({
                 pageLimit: 1000
             }
         };
-        if (this.model.get('value')){       
+        if (this.model.get('value')) {
             this.getRoot(this.model.get('value'), itemSelectorSettings);
         } else {
             this.completeInitialization(itemSelectorSettings);

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -252,11 +252,21 @@ const ControlWidget = View.extend({
      */
     _selectFile() {
         // If we converted to multi, convert it back to the older type
+        // We reset the name if it was multi before
+        if (this.model.get('type') === 'multi') {
+            if (this.model.get('value')){
+                this.model.set({
+                    value: new ItemModel({
+                        folderId: this.model.get('value').get('folderId')
+                    })
+                });
+            }
+        }
         const t = this.model.get('defaultType');
+
         if (t) {
             this.model.set({
                 type: t,
-                value: undefined
             });
         }
         const modal = new ItemSelectorWidget({
@@ -275,11 +285,12 @@ const ControlWidget = View.extend({
     _selectMultiFile() {
         // Store the current type in case it is opened again
         const t = this.model.get('type');
-        this.model.set({
-            type: 'multi',
-            defaultType: t,
-            value: undefined
-        });
+        if (t !== 'multi'){
+            this.model.set({
+                type: 'multi',
+                defaultType: t,
+            });
+        }
         const modal = new ItemSelectorWidget({
             el: $('#g-dialog-container'),
             parentView: this,

--- a/slicer_cli_web/web_client/views/ControlWidget.js
+++ b/slicer_cli_web/web_client/views/ControlWidget.js
@@ -290,7 +290,7 @@ const ControlWidget = View.extend({
     },
     /**
      * Used to collect the root of the resource passed to the itemSelectorWidget to enable the defaultSelectedResource
-     * The value is not an actual model so we need to fetch the model from the itemId, folderID, or if it is the item, the actual item
+     * The value isn't always a valid model so we need to fetch the model from the itemId, folderID, or if it is the item, the actual item
      * @param {*} resource - value object for model containing either itemId, folderId, or a standard model
      * @param {*} settings - ItemSelectorWidget settings extended from BrowserWidget
      */

--- a/slicer_cli_web/web_client/views/ItemSelectorWidget.js
+++ b/slicer_cli_web/web_client/views/ItemSelectorWidget.js
@@ -17,7 +17,7 @@ const ItemSelectorWidget = BrowserWidget.extend({
         settings.submitText = 'Confirm';
 
         settings.validate = (model) => this._validateModel(model);
-       if (!settings.defaultSelectedResource && !(settings.rootSelectorSettings && settings.rootSelectorSettings.selectByResource) ) {
+        if (!settings.defaultSelectedResource && !(settings.rootSelectorSettings && settings.rootSelectorSettings.selectByResource)) {
             settings.root = settings.rootPath || getCurrentUser();
         }
         if (settings.root === false && !settings.defaultSelectedResource) {
@@ -161,7 +161,7 @@ const ItemSelectorWidget = BrowserWidget.extend({
                 });
             } else {
                 // When initialized the itemListView doesn't exist to process the regularExpression
-                // wait until it is visible and then apply it
+                // wait until items are added to highlight based on regularExpression
                 this.checkItemsLoaded(100);
             }
         }
@@ -172,7 +172,7 @@ const ItemSelectorWidget = BrowserWidget.extend({
      * @param {number} timeout
      */
     checkItemsLoaded(timeout) {
-        if (this.$('.g-folder-list-entry').length || this.$('.g-item-list-entry').length) {
+        if (this.$('.g-folder-list').length || this.$('.g-item-list').length) {
             clearTimeout(this.checkItemsTimeout);
             this.processRegularExpression();
         } else {

--- a/slicer_cli_web/web_client/views/ItemSelectorWidget.js
+++ b/slicer_cli_web/web_client/views/ItemSelectorWidget.js
@@ -17,10 +17,10 @@ const ItemSelectorWidget = BrowserWidget.extend({
         settings.submitText = 'Confirm';
 
         settings.validate = (model) => this._validateModel(model);
-        if (settings.root === undefined) {
+       if (!settings.defaultSelectedResource && !(settings.rootSelectorSettings && settings.rootSelectorSettings.selectByResource) ) {
             settings.root = settings.rootPath || getCurrentUser();
         }
-        if (settings.root === false) {
+        if (settings.root === false && !settings.defaultSelectedResource) {
             settings.root = null;
         }
 
@@ -33,19 +33,16 @@ const ItemSelectorWidget = BrowserWidget.extend({
             case 'file':
                 settings.titleText = 'Select a file';
                 settings.selectItem = true;
-                settings.highlightItem = true;
                 settings.showPreview = false;
                 break;
             case 'image':
                 settings.titleText = 'Select an image';
                 settings.selectItem = true;
-                settings.highlightItem = true;
                 settings.showPreview = false;
                 break;
             case 'item':
                 settings.titleText = 'Select an item';
                 settings.selectItem = true;
-                settings.highlightItem = true;
                 settings.showPreview = false;
                 break;
             case 'multi':

--- a/tests/web_client_specs/itemSelectorWidgetSpec.js
+++ b/tests/web_client_specs/itemSelectorWidgetSpec.js
@@ -28,6 +28,7 @@ describe('browser hierarchy paginated selection', function () {
             parentView: this,
             el: dialogEl,
             rootPath: folder,
+            root: folder,
             defaultSelectedResource: item,
             selectItem: true,
             showItems: true,

--- a/tests/web_client_specs/widgetSpec.js
+++ b/tests/web_client_specs/widgetSpec.js
@@ -1110,4 +1110,171 @@ describe('control widget getRoot', function () {
 
         }, 'folder should be the root');
     });
+
+    it('parentCollection', function () {
+        var arg, file, item, folder, w;
+        runs(function () {
+            item = new girder.models.ItemModel({_id: 'item id', name: 'd', folderId: 'folder id'});
+            file = new girder.models.FileModel({_id: 'file id', name: 'e'});
+            folder = new girder.models.FolderModel({ _id: 'folder id', name: 'f', parentId: 'admin', parentCollection:'user' });
+            hProto.initialize = function (_arg) {
+                arg = _arg;
+                this.breadcrumbs = [];
+            };
+            hProto.render = function () {};
+            w = new slicer.views.ControlWidget({
+                rootPath: admin,
+                parentView: parentView,
+                el: $el.get(0),
+                model: new slicer.models.WidgetModel({
+                    type: 'file',
+                    title: 'Title',
+                    id: 'file-widget',
+                    value: new girder.models.ItemModel({
+                        'parentCollection': 'user',
+                        'parentId': 'admin',
+                    })
+                })
+            });
+
+            w.render();
+            checkWidgetCommon(w);
+            initializationSettings = false;
+
+
+            spyOn(girder.rest, 'restRequest').andCallFake(function (opts) {
+                if (opts.url.substr(0, 11) === 'collection/'){
+                    return $.Deferred().resolve(user.toJSON());
+                }
+                if (opts.url.substr(0, 5) === 'item/') {
+                    return $.Deferred().resolve(item.toJSON());
+                }
+                if (opts.url.substr(0, 7) === 'folder/') {
+                    return $.Deferred().resolve(folder.toJSON());
+                }
+                return $.Deferred().resolve([item.toJSON()]);
+            });
+            expect(w.$('.s-select-multifile-button').length).toBe(1);
+            w.$('.s-select-file-button').click();
+        });
+        waitsFor(function () {
+            return initializationSettings !== false;
+        }, 'the initialization settings to change');
+        runs(function () {
+            expect(initializationSettings.root.get('_id')).toBe(admin.get('_id'))
+
+        }, 'admin should be the root');
+    });
+
+    it('itemId error root test', function () {
+        var arg, file, item, folder, w;
+        runs(function () {
+            item = new girder.models.ItemModel({_id: 'item id', name: 'd', folderId: 'folder id'});
+            file = new girder.models.FileModel({_id: 'file id', name: 'e'});
+            folder = new girder.models.FolderModel({ _id: 'folder id', name: 'f', parentId: 'admin', parentCollection:'user' });
+            hProto.initialize = function (_arg) {
+                arg = _arg;
+                this.breadcrumbs = [];
+            };
+            hProto.render = function () {};
+            w = new slicer.views.ControlWidget({
+                rootPath: admin,
+                parentView: parentView,
+                el: $el.get(0),
+                model: new slicer.models.WidgetModel({
+                    type: 'file',
+                    title: 'Title',
+                    id: 'file-widget',
+                    value: new girder.models.ItemModel({
+                        "itemId": 'fake item id',
+                        name: 'd'
+                    })
+                })
+            });
+
+            w.render();
+            checkWidgetCommon(w);
+            initializationSettings = false;
+
+
+            spyOn(girder.rest, 'restRequest').andCallFake(function (opts) {
+                if (opts.url.substr(0, 11) === 'collection/'){
+                    return $.Deferred().resolve(user.toJSON());
+                }
+                if (opts.url.substr(0, 5) === 'item/') {
+                    return $.Deferred().reject(item.toJSON());
+                }
+                if (opts.url.substr(0, 7) === 'folder/') {
+                    return $.Deferred().resolve(folder.toJSON());
+                }
+                return $.Deferred().resolve([item.toJSON()]);
+            });
+            expect(w.$('.s-select-multifile-button').length).toBe(1);
+            w.$('.s-select-file-button').click();
+        });
+        waitsFor(function () {
+            return initializationSettings !== false;
+        }, 'the initialization settings to change');
+        runs(function () {
+            expect(initializationSettings.root).toBe(null);
+
+        }, 'root should be null');
+    });
+
+    it('folderId error root test', function () {
+        var arg, file, item, folder, w;
+        runs(function () {
+            item = new girder.models.ItemModel({_id: 'item id', name: 'd', folderId: 'folder id'});
+            file = new girder.models.FileModel({_id: 'file id', name: 'e'});
+            folder = new girder.models.FolderModel({ _id: 'folder id', name: 'f', parentId: 'admin', parentCollection:'user' });
+            hProto.initialize = function (_arg) {
+                arg = _arg;
+                this.breadcrumbs = [];
+            };
+            hProto.render = function () {};
+            w = new slicer.views.ControlWidget({
+                rootPath: admin,
+                parentView: parentView,
+                el: $el.get(0),
+                model: new slicer.models.WidgetModel({
+                    type: 'file',
+                    title: 'Title',
+                    id: 'file-widget',
+                    value: new girder.models.ItemModel({
+                        "folderId": 'folder id',
+                        name: 'd'
+                    })
+                })
+            });
+
+            w.render();
+            checkWidgetCommon(w);
+            initializationSettings = false;
+
+
+            spyOn(girder.rest, 'restRequest').andCallFake(function (opts) {
+                if (opts.url.substr(0, 11) === 'collection/'){
+                    return $.Deferred().resolve(user.toJSON());
+                }
+                if (opts.url.substr(0, 5) === 'item/') {
+                    return $.Deferred().resolve(item.toJSON());
+                }
+                if (opts.url.substr(0, 7) === 'folder/') {
+                    return $.Deferred().reject(folder.toJSON());
+                }
+                return $.Deferred().resolve([item.toJSON()]);
+            });
+            expect(w.$('.s-select-multifile-button').length).toBe(1);
+            w.$('.s-select-file-button').click();
+        });
+        waitsFor(function () {
+            return initializationSettings !== false;
+        }, 'the initialization settings to change');
+        runs(function () {
+            expect(initializationSettings.root).toBe(null);
+
+        }, 'root should be null');
+    });
+    
+
 });


### PR DESCRIPTION
Adding in the capability to open to a previously selected item as well as adding in pagination to the items.

Swapping between RegEx and Single files should work by opening the same folder as the regex or single file when switching between the two.  Now when opening a single item or multiSelect it should go directly to the proper folder.

![examplePaginationSelection](https://user-images.githubusercontent.com/61746913/103297883-30bdd980-49c7-11eb-8f69-d73374dc8a35.gif)


The one thing I'm not exactly happy about is the default highlighting when loading a previously accepted regEx multi file selection.  I need to know when the folderList/ItemList is loaded entirely but it is deeply nested inside of the BrowserWidget -> Hierarchy Widget -> ItemWidget -> the individual items.  If you reach inside of the BrowserWidget to the HierarchyWidget  you would need to do cascading loading of the individual items to figure out when the items were rendered. For right now I put in a timeout checking for when `g-folder-list` or `g-item-list`.

The other thing that is needed to go to the selected resource is a way to take the current selected `value` in the the returned item and calculate the root folder or collection in the system.  So that is what `getRoot` is doing inside of `ControlWidget.js`.  It attempts to figure out what the root is based on the selected value and will default back to the user root if it can't figure it out.

