### PR TITLE
Remove flake8-blind-except.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ skipsdist = true
 skip_install = true
 deps =
   flake8
-  flake8-blind-except
   flake8-bugbear; python_version >= '3.5'
   flake8-docstrings
   flake8-quotes


### PR DESCRIPTION
flake8 takes care of this and flake8-blind-except now throws additional, undesired errors.