### PR TITLE
Stop using pkg_resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.6.12
+          version: 3.6.15
       - tox:
           env: py36
       - coverage
@@ -109,7 +109,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.7.9
+          version: 3.7.12
       - tox:
           env: py37
       - coverage
@@ -119,7 +119,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.8.6
+          version: 3.8.12
       - tox:
           env: py38
       - coverage
@@ -129,9 +129,19 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.9.0
+          version: 3.9.10
       - tox:
           env: py39
+      - coverage
+  py310:
+    machine:
+        image: ubuntu-2004:202111-02
+    steps:
+      - checkout
+      - allservices:
+          version: 3.10.2
+      - tox:
+          env: py310
       - coverage
   small-docker:
     machine:
@@ -214,6 +224,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - py310:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - lint_and_docs:
           filters:
             tags:
@@ -241,6 +258,7 @@ workflows:
             - py37
             - py38
             - py39
+            - py310
             - lint_and_docs
           filters:
             tags:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     include_package_data=True,
     package_dir={'girder_slicer_cli_web': 'slicer_cli_web'},
@@ -55,6 +56,7 @@ setup(
         'jinja2',
         'jsonschema>=2.5.1',
         'pyyaml>=5.1.2',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': [

--- a/slicer_cli_web/__init__.py
+++ b/slicer_cli_web/__init__.py
@@ -1,4 +1,4 @@
-###############################################################################
+#############################################################################
 #  Copyright Kitware Inc.
 #
 #  Licensed under the Apache License, Version 2.0 ( the "License" );
@@ -12,14 +12,22 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-###############################################################################
+#############################################################################
 
-from pkg_resources import DistributionNotFound, get_distribution
+# These two imports must be in this order for appropriate side effects
 
+from . import ctk_cli_adjustment  # noqa
+from ctk_cli import CLIArgumentParser  # noqa
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 


### PR DESCRIPTION
importlib is significantly faster, which results in speeding up importing the library

Also, import ctk_cli CLIArgumentParser so tools can do `from slicer_cli_web import CLIArgumentParser` to get the appropriate modified version.