### PR TITLE
Better conform to the slicer execution model.

### DIFF
--- a/small-docker/Example1/Example1.xml
+++ b/small-docker/Example1/Example1.xml
@@ -72,12 +72,14 @@
       <description><![CDATA[An enumeration of strings]]></description>
       <label>String Enumeration Parameter</label>
       <default>Bill</default>
-      <element>Ron</element>
-      <element>Eric</element>
-      <element>Bill</element>
-      <element>Ross</element>
-      <element>Steve</element>
-      <element>Will</element>
+      <enumeration>
+        <element>Ron</element>
+        <element>Eric</element>
+        <element>Bill</element>
+        <element>Ross</element>
+        <element>Steve</element>
+        <element>Will</element>
+      </enumeration>
     </string-enumeration>
   </parameters>
   <parameters advanced="true">

--- a/utils/xmltojson.py
+++ b/utils/xmltojson.py
@@ -1,11 +1,13 @@
 # requires xmljson
 
 import argparse
-from collections import OrderedDict
 import json
 import sys
+from collections import OrderedDict
+
 import xmljson
 import yaml
+
 try:
     from lxml.etree import parse
 except ImportError:
@@ -64,8 +66,10 @@ if __name__ == '__main__':  # noqa
                         for k, v in param['constraints'].items():
                             param['constraints'][k] = cast(v)
                     group['parameters'].append(param)
-                    if key.endswith('-enumeration') and param.get('element'):
-                        enumer = param.pop('element')
+                    if key.endswith('-enumeration') and (
+                            param.get('element') or param.get('enumeration')):
+                        enumer = (param.pop('element') if param.get('element') else
+                                  param.pop('enumeration').pop('element'))
                         if not isinstance(enumer, list):
                             enumer = list(enumer)
                         param['enumeration'] = [cast(v) for v in enumer]


### PR DESCRIPTION
Enumeration elements should be wrapped in an `<enumeration>` tag.