### PR TITLE
Improve css rules.

### DIFF
--- a/slicer_cli_web/web_client/stylesheets/panel.styl
+++ b/slicer_cli_web/web_client/stylesheets/panel.styl
@@ -28,10 +28,11 @@
     .s-panel-controls
       float right
 
-.g-jobs-list-table tbody>tr td
-  white-space nowrap
-  a
-    max-width 235px
-    text-overflow ellipsis
-    overflow hidden
-    display block
+.s-panel
+  .g-jobs-list-table tbody>tr td
+    white-space nowrap
+    a
+      max-width 235px
+      text-overflow ellipsis
+      overflow hidden
+      display block


### PR DESCRIPTION
Don't adjust the jobs name length outside of the panel context.