### PR TITLE
Pin importlib-metadata for python 3.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'jinja2',
         'jsonschema',
         'pyyaml',
-        'importlib-metadata ; python_version < "3.8"',
+        'importlib-metadata<5 ; python_version < "3.8"',
     ],
     extras_require={
         'girder': [


### PR DESCRIPTION
This is needed for the version of celery we use.