### PR TITLE
Handle the latest version of pytest-xdist.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
   mock
   pytest>=3.6
   pytest-cov>=2.6
+  pytest-forked
   pytest-girder>=3.0.4
   pytest-mock
   pytest-xdist


### PR DESCRIPTION
Explicitly require pytest-forked.