### PR TITLE
Fix a bug that could use more memory in docker progress reporting.

### DIFF
--- a/slicer_cli_web/girder_worker_plugin/cli_progress.py
+++ b/slicer_cli_web/girder_worker_plugin/cli_progress.py
@@ -33,7 +33,7 @@ class CLIProgressCLIWriter(StreamWriter):
 
     def write(self, buf):
         act = self._buf + buf
-        self.buf = b''
+        self._buf = b''
 
         if b'</filter-' not in act:
             if b'<filter-' in act:

--- a/small-docker/ExampleProgress/ExampleProgress.json
+++ b/small-docker/ExampleProgress/ExampleProgress.json
@@ -21,7 +21,7 @@
           "default": 10
         },
         {
-          "type": "integer",
+          "type": "double",
           "name": "Sleep",
           "longflag": "sleep",
           "label": "sleep",

--- a/small-docker/ExampleProgress/ExampleProgress.py
+++ b/small-docker/ExampleProgress/ExampleProgress.py
@@ -14,14 +14,15 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--count', dest='count', type=int, default=10)
-    parser.add_argument('--sleep', dest='sleep', type=int, default=1)
+    parser.add_argument('--sleep', dest='sleep', type=float, default=1)
 
     args = parser.parse_args()
-    with ProgressHelper('Example', 'sleeping mostly') as p:
+    with ProgressHelper('Example', 'Sleeping mostly') as p:
         for i in range(args.count):
-            print('doing some complicated things...')
+            print('Sleeping...')
             if i:
                 p.message('Sleeping for %g seconds' % ((args.count - i) * args.sleep))
             p.progress(float(i) / args.count)
             time.sleep(args.sleep)
+        p.message('Done')
         p.progress(1)


### PR DESCRIPTION
Allow the example progress to have float values for durations.