### PR TITLE
On long running batch jobs, allow refreshing mongo cursors

### DIFF
--- a/example-average-color/Dockerfile
+++ b/example-average-color/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
-MAINTAINER David Manthey <david.manthey@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 RUN pip install --find-links https://girder.github.io/large_image_wheels large_image[sources]
 RUN pip install girder-slicer-cli-web
 
-COPY . $PWD
+COPY . /
 ENTRYPOINT ["python", "./cli_list.py"]

--- a/example-average-color/README.rst
+++ b/example-average-color/README.rst
@@ -3,18 +3,18 @@ average color of a large image.
 
 To build, use docker in this directory::
 
-    docker build --force-rm -t girder/slicer_cli_web:average_color .
+    docker build --force-rm -t girder/slicer_cli_web:example-average-color .
 
 To run, you'll need an image that can be read by the large_image library.
 You can run this as a command line, mounting a directory for input and output,
 like so::
 
-    docker run --rm -t -v /local/image/path:/input:ro -v /local/output/path:/output --rm -it girder/slicer_cli_web:average_color average_color /input/sample_image.svs /output/annotation.json --returnparameterfile /output/results.txt --channel=red
+    docker run --rm -t -v /local/image/path:/input:ro -v /local/output/path:/output --rm -it girder/slicer_cli_web:example-average-color average_color /input/sample_image.svs /output/metadata.json --returnparameterfile /output/results.txt --channel=red
 
 You can also enumerate available algorithms::
 
-    docker run --rm -t girder/slicer_cli_web:average_color --list_cli
+    docker run --rm -t girder/slicer_cli_web:example-average-color --list_cli
 
 And get help for the one available algorithm::
 
-    docker run --rm -t girder/slicer_cli_web:average_color average_color --help
+    docker run --rm -t girder/slicer_cli_web:example-average-color average_color --help

--- a/example-average-color/average_color/average_color.xml
+++ b/example-average-color/average_color/average_color.xml
@@ -29,16 +29,15 @@
     </string-enumeration>
     <float>
       <name>average</name>
-      <longflag>average</longflag>
       <label>Average color</label>
       <description>The average color</description>
       <channel>output</channel>
       <default>0</default>
     </float>
-    <file fileExtensions=".anot" reference="ImageFile">
-      <name>outputAnnotationFile</name>
-      <label>Output Annotation File</label>
-      <description>Output annotation file (*.anot)</description>
+    <file fileExtensions=".json" reference="imageFile">
+      <name>outputItemMetadata</name>
+      <label>Output Metadata File</label>
+      <description>Output metadata file (*.json)</description>
       <channel>output</channel>
       <index>1</index>
     </file>

--- a/slicer_cli_web/web_client/views/ItemSelectorWidget.js
+++ b/slicer_cli_web/web_client/views/ItemSelectorWidget.js
@@ -119,7 +119,7 @@ const ItemSelectorWidget = BrowserWidget.extend({
             this.$('.g-item-list-entry').each((index, item) => {
                 if (this.$(item)) {
                     item = this.$(item);
-                    const link = item.find('.g-item-list-link[href]').filter((idx, l) => { console.log(idx, l); return $(l).find('i.icon-doc-text-inv').length; });
+                    const link = item.find('.g-item-list-link[href]').filter((idx, l) => $(l).find('i.icon-doc-text-inv').length);
                     const text = link.text();
                     if (text.match(regEx) || reg === '') {
                         this.$(item).addClass('g-selected');


### PR DESCRIPTION
Update the average color example to better match documentation and not show needless warnings.