### PR TITLE
Permit optional output files to be blank.

### DIFF
--- a/slicer_cli_web/prepare_task.py
+++ b/slicer_cli_web/prepare_task.py
@@ -189,7 +189,8 @@ def _add_optional_output_param(param, args, user, result_hooks, reference, templ
     ref = reference.copy()
     ref['identifier'] = param.identifier()
     result_hooks.append(GirderUploadVolumePathToFolder(
-        path, folder, upload_kwargs={'reference': json.dumps(ref)}))
+        path, folder, must_exist=False,
+        upload_kwargs={'reference': json.dumps(ref)}))
 
     return container_args
 

--- a/slicer_cli_web/web_client/views/ItemSelectorWidget.js
+++ b/slicer_cli_web/web_client/views/ItemSelectorWidget.js
@@ -69,7 +69,7 @@ const ItemSelectorWidget = BrowserWidget.extend({
                 settings.input = {
                     label: 'Item name',
                     validate: (val) => {
-                        if (val && val.trim()) {
+                        if ((val && val.trim()) || (!val && !this.model.required)) {
                             return $.Deferred().resolve().promise();
                         }
                         return $.Deferred().reject('Specify an item name').promise();
@@ -264,14 +264,22 @@ const ItemSelectorWidget = BrowserWidget.extend({
                 });
                 break;
             case 'new-file':
-                this.model.set({
-                    path: this._path(),
-                    parent: model,
-                    value: new ItemModel({
-                        name: fileName,
-                        folderId: model.id
-                    })
-                });
+                if (!fileName) {
+                    this.model.set({
+                        path: this._path(),
+                        parent: model,
+                        value: null
+                    });
+                } else {
+                    this.model.set({
+                        path: this._path(),
+                        parent: model,
+                        value: new ItemModel({
+                            name: fileName,
+                            folderId: model.id
+                        })
+                    });
+                }
                 break;
             case 'multi':
                 if (fileName.trim() === '') {


### PR DESCRIPTION
This updates the UI to allow the file name to be cleared.  It passes the appropriate flag to the girder transform.