### PR TITLE
Fix an assumption about parameter defaults

### DIFF
--- a/slicer_cli_web/ctk_cli_adjustment.py
+++ b/slicer_cli_web/ctk_cli_adjustment.py
@@ -120,6 +120,11 @@ class CLIParameter(ctk_cli.module.CLIParameter):
             except ValueError as e:
                 ctk_cli.module.logger.warning('Could not parse default value of <%s> (%s): %s' % (
                     ctk_cli.module._tag(elementTree), self.name, e))
+        elif (self.typ not in {'float', 'integer', 'boolean'} and
+                not self.isVector() and not self.isExternalType() and
+                self.channel != 'output'):
+            ctk_cli.module.logger.warning(
+                'No <default> provided for element of type <%s>', self.typ)
 
         if self.typ.endswith('-enumeration'):
             try:

--- a/slicer_cli_web/rest_slicer_cli.py
+++ b/slicer_cli_web/rest_slicer_cli.py
@@ -50,7 +50,7 @@ def _getParamDefaultVal(param):
         return None
     elif param.isExternalType():
         return None
-    elif param.typ == 'float' or param.typ == 'integer':
+    elif param.typ in {'float', 'double', 'integer'}:
         return 0
     else:
         raise Exception(


### PR DESCRIPTION
Specifically, we don't require a default for float or integer values but did for double.  Be consistent.

Add a warning when we expect but don't have a default.