### PR TITLE
Add support that a job can trigger a sub-job with the right permissions

### DIFF
--- a/slicer_cli_web/rest_slicer_cli.py
+++ b/slicer_cli_web/rest_slicer_cli.py
@@ -473,10 +473,20 @@ def genHandlerToRunDockerCLI(cliItem):  # noqa C901
         Job().save(jobRecord)
         return job
 
-    @access.user
+    @access.token
     @describeRoute(handlerDesc)
     def cliHandler(resource, params):
         user = resource.getCurrentUser()
+        token = resource.getCurrentToken()
+        try:
+            from girder_jobs.constants import REST_CREATE_JOB_TOKEN_SCOPE
+
+            if (user is None and token and token.get('access', {}) and
+                    len(token['access'].get('users', [])) == 1):
+                Token().requireScope(token, REST_CREATE_JOB_TOKEN_SCOPE)
+                user = User().load(id=token['access']['users'][0]['id'], force=True)
+        except Exception:
+            pass
         currentItem = CLIItem.find(itemId, user)
         if not currentItem:
             raise RestException('Invalid CLI Item id (%s).' % (itemId))

--- a/small-docker/Dockerfile
+++ b/small-docker/Dockerfile
@@ -1,6 +1,6 @@
 # Use a version of alpine that includes bash and python
 FROM python:3.11-alpine
-MAINTAINER David Manthey <david.manthey@kitware.com>
+LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # Since we are using a BusyBox variant, we need to use addgroup and adduser,
 # rather than let girder_worker use groupadd and useradd.  Those will fail,
@@ -14,7 +14,7 @@ RUN chmod a+x /usr/local/bin/groupadd
 RUN touch /usr/local/bin/useradd
 RUN chmod a+x /usr/local/bin/useradd
 
-RUN pip install --no-cache-dir girder-slicer-cli-web
-COPY . $PWD
+RUN pip install --no-cache-dir girder-slicer-cli-web girder-client
+COPY . .
 
 ENTRYPOINT ["python", "./cli_list.py"]

--- a/small-docker/cli_list.json
+++ b/small-docker/cli_list.json
@@ -28,5 +28,9 @@
   "ExampleProgress": {
     "type": "python",
     "desc-type": "json"
+  },
+  "ExampleSubJob": {
+    "type": "python",
+    "desc-type": "json"
   }
 }

--- a/tests/test_rest_slicer_cli.py
+++ b/tests/test_rest_slicer_cli.py
@@ -3,11 +3,13 @@ import json
 import os
 import time
 
+import cherrypy
 import pytest
 from girder.api import rest
 from girder.models.collection import Collection
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.models.token import Token
 from pytest_girder.assertions import assertStatusOk
 
 from slicer_cli_web import docker_resource, rest_slicer_cli
@@ -20,6 +22,7 @@ def handlerFunc(server, admin, folder, file):
     # testing outside of a request for the actual handler.
     server.request('/system/version')
     rest.setCurrentUser(admin)
+    cherrypy.request.params['token'] = Token().createToken(admin)['_id']
 
     xmlpath = os.path.join(os.path.dirname(__file__), 'data', 'ExampleSpec.xml')
 
@@ -40,6 +43,7 @@ def handlerRerunFuncs(server, admin, folder, file):
     # testing outside of a request for the actual handler.
     server.request('/system/version')
     rest.setCurrentUser(admin)
+    cherrypy.request.params['token'] = Token().createToken(admin)['_id']
 
     xmlpath = os.path.join(os.path.dirname(__file__), 'data', 'ExampleSpec.xml')
 


### PR DESCRIPTION
For a job to create a sub-job, it will require permissions via girder worker to create such a job.  See other documentation for that purpose.